### PR TITLE
Keep state up to date in node view

### DIFF
--- a/EmbedWrapper.js
+++ b/EmbedWrapper.js
@@ -1,13 +1,25 @@
-import { h, Component } from 'preact';
+import { h } from 'preact';
 
 const EmbedWrapper = ({ name, moveUp, moveDown, remove, children }) => (
   <div>
     <div>{name}</div>
     <div>{children}</div>
     <div>
-      {moveUp && <button onClick={moveUp}>↑</button>}
-      {moveDown && <button onClick={moveDown}>↓</button>}
-      {remove && <button onClick={remove}>✕</button>}
+      {moveUp && (
+        <button disabled={!moveUp(false)} onClick={moveUp}>
+          ↑
+        </button>
+      )}
+      {moveDown && (
+        <button disabled={!moveDown(false)} onClick={moveDown}>
+          ↓
+        </button>
+      )}
+      {remove && (
+        <button disabled={!remove(false)} onClick={remove}>
+          ✕
+        </button>
+      )}
     </div>
   </div>
 );

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,103 @@
+import { AllSelection } from 'prosemirror-state';
+// import { canJoin } from 'prosemirror-transform';
+import { DecorationSet, Decoration } from 'prosemirror-view';
+
+const nodesBetween = (state, _from, _to) => {
+  const dir = _to - _from;
+  const range = [_from, _to];
+  range.sort((a, b) => a - b);
+  const [from, to] = range;
+  let arr = [];
+  state.doc.nodesBetween(from, to, (...args) => arr.push(args));
+  if (dir < 0) {
+    arr.reverse();
+  }
+  return arr;
+};
+
+const defaultPredicate = (node, pos, parent) =>
+  parent.type.name === 'doc' && node.textContent;
+
+const moveNode = (pos, predicate, state, dispatch, dir) => {
+  const all = new AllSelection(state.doc);
+
+  const [nextNode, nextNodePos] =
+    nodesBetween(state, pos, dir < 0 ? all.from : all.to).find(args =>
+      predicate(...args)
+    ) || [];
+
+  if (typeof nextNodePos === 'undefined') {
+    return false;
+  }
+
+  if (!dispatch) {
+    return true;
+  }
+
+  const nodePos = dir < 0 ? nextNodePos : nextNodePos + nextNode.nodeSize;
+
+  const { node } = state.doc.childAfter(pos);
+
+  const tr = state.tr.deleteRange(pos, pos + 1);
+  const insertPos = tr.mapping.mapResult(nodePos).pos;
+  tr.insert(insertPos, node.type.create({ ...node.attrs }));
+
+  const mappedPos = tr.mapping.mapResult(pos).pos;
+  // merge the surrounding blocks if possible
+  // this is only useful if we have root `textElement` nodes like in composer
+  // as the time of this commit
+  // if (canJoin(tr.doc, mappedPos)) {
+  //   tr.join(mappedPos);
+  // }
+
+  dispatch(tr);
+};
+
+const moveNodeUp = (pos, predicate = defaultPredicate) => (state, dispatch) =>
+  moveNode(pos, predicate, state, dispatch, -1);
+
+const moveNodeDown = (pos, predicate = defaultPredicate) => (state, dispatch) =>
+  moveNode(pos, predicate, state, dispatch, 1);
+
+const removeNode = pos => (state, dispatch) => {
+  if (!dispatch) {
+    return true;
+  }
+  const pos = pos();
+  dispatch(state.tr.deleteRange(pos, pos + 1));
+};
+
+const buildCommands = (pos, state, dispatch) => ({
+  moveUp: (run = true) => moveNodeUp(pos)(state, run && dispatch),
+  moveDown: (run = true) => moveNodeDown(pos)(state, run && dispatch),
+  remove: (run = true) => removeNode(pos)(state, run && dispatch)
+});
+
+const stateToNodeView = name => ({
+  packDecos: state => {
+    let decorations = [];
+    state.doc.descendants((node, pos) => {
+      if (node.type.name === name) {
+        decorations.push(
+          Decoration.node(
+            pos,
+            pos + 1,
+            {
+              type: 'embed',
+              state
+            },
+            {
+              inclusiveStart: false,
+              inclusiveEnd: false
+            }
+          )
+        );
+      }
+    });
+    return DecorationSet.create(state.doc, decorations);
+  },
+  unpackDeco: decorations =>
+    decorations.find(deco => deco.type.attrs.type === name).type.attrs.state
+});
+
+export { buildCommands, stateToNodeView };

--- a/image-embed.js
+++ b/image-embed.js
@@ -8,19 +8,13 @@ class ImageEmbed extends Component {
     this.handleNameChange = this.handleNameChange.bind(this);
 
     this.state = {
+      commands: this.props.commands,
       fields: this.props.fields
     };
   }
 
   componentDidMount() {
-    this.props.updater.subscribe(fields =>
-      this.setState(
-        {
-          fields
-        },
-        false
-      )
-    );
+    this.props.updater.subscribe(state => this.setState(state, false));
   }
 
   setState(state, notifyListeners = true) {
@@ -43,7 +37,7 @@ class ImageEmbed extends Component {
 
   render() {
     return (
-      <EmbedWrapper name="Image">
+      <EmbedWrapper name="Image" {...this.state.commands}>
         <input
           type="text"
           value={this.state.fields.name}
@@ -54,14 +48,14 @@ class ImageEmbed extends Component {
   }
 }
 
-const mount = () => (dom, updateFields, fields) => {
+const mount = () => (dom, updateFields, fields, commands) => {
   const createUpdater = () => {
     let sub = () => {};
     return {
       subscribe: fn => {
         sub = fn;
       },
-      setFields: fields => sub(fields)
+      update: (...args) => sub(...args)
     };
   };
   const updater = createUpdater();
@@ -70,10 +64,11 @@ const mount = () => (dom, updateFields, fields) => {
       onStateChange={updateFields}
       fields={fields}
       updater={updater}
+      commands={commands}
     />,
     dom
   );
-  return updater.setFields;
+  return updater.update;
 };
 
 export default mount;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prosemirror-model": "^1.6.0",
     "prosemirror-schema-basic": "^1.0.0",
     "prosemirror-state": "^1.2.2",
+    "prosemirror-transform": "^1.1.3",
     "prosemirror-view": "^1.3.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,7 +3427,7 @@ prosemirror-state@^1.0.0, prosemirror-state@^1.2.2:
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0:
+prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.1.3.tgz#28cfdf1f9ee514edc40466be7b7db39eed545fdf"
   dependencies:


### PR DESCRIPTION
It seems there isn't a simple way for node views to subscribe to global state changes. In fact as marijn says [here](https://discuss.prosemirror.net/t/setting-up-a-nodeview-that-needs-context/843/2?u=rich) that

> node views should be treated as depending only on the node and its content, and no other external values

But I'm not sure I totally agree so have [asked for clarity](https://discuss.prosemirror.net/t/commands-inside-a-node-view/1440), and until then have implemented the idea discussed in that post.