### PR TITLE
Add RTENodeView 

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "integrationFolder": "cypress/tests"
+  "integrationFolder": "cypress/tests",
+  "baseUrl": "http://localhost:7890"
 }

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -19,21 +19,14 @@ export const getElementType = (element: JQuery) => {
 
 export const addEmbed = () => cy.get("#embed").click();
 
-export const typeIntoProsemirror = (content: string, paragraphIndex = 1) =>
-  cy.get(`.ProseMirror p:nth-child(${paragraphIndex})`).type(content);
+export const typeIntoProsemirror = (content: string) =>
+  cy.get(`.ProseMirror`).type(content);
 
-export const getEmbedField = (fieldName: string, paragraphIndex = 1) =>
-  cy.get(
-    `div${selectDataCy(
-      getNestedViewTestId(fieldName)
-    )} .ProseMirror p:nth-child(${paragraphIndex})`
-  );
+export const getEmbedField = (fieldName: string) =>
+  cy.get(`div${selectDataCy(getNestedViewTestId(fieldName))} .ProseMirror`);
 
-export const typeIntoEmbedField = (
-  fieldName: string,
-  content: string,
-  paragraphIndex = 1
-) => getEmbedField(fieldName, paragraphIndex).type(content);
+export const typeIntoEmbedField = (fieldName: string, content: string) =>
+  getEmbedField(fieldName).type(content);
 
 export const getArrayOfBlockElementTypes = () => {
   // eslint-disable-next-line prefer-const -- it is used.

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,5 +1,6 @@
 import { Plugin } from "prosemirror-state";
-import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { EditorView } from "prosemirror-view";
+import { Decoration, DecorationSet } from "prosemirror-view";
 import { embedWrapperTestId } from "../../src/mounters/react/EmbedWrapper";
 import { getNestedViewTestId } from "../../src/mounters/react/NestedEditorView";
 import { docToHtml } from "../../src/prosemirrorSetup";
@@ -38,8 +39,10 @@ export const getEmbedMenuButton = (fieldName: string, buttonTitle: string) =>
     )} .ProseMirror-menubar [title="${buttonTitle}"]`
   );
 
+// If we don't focus the nested RTE we're typing into before type() is called,
+// Cypress tends to type into the parent RTE instead.
 export const typeIntoEmbedField = (fieldName: string, content: string) =>
-  getEmbedField(fieldName).type(content);
+  getEmbedField(fieldName).focus().type(content);
 
 export const getArrayOfBlockElementTypes = () => {
   // eslint-disable-next-line prefer-const -- it is used.

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -44,7 +44,6 @@ export const getArrayOfBlockElementTypes = () => {
   // eslint-disable-next-line prefer-const -- it is used.
   let elementTypes = [] as string[];
   return new Cypress.Promise((resolve) => {
-    console.log(cy.get("#editor .ProseMirror-menubar-wrapper .ProseMirror"));
     cy.get("#editor > .ProseMirror-menubar-wrapper > .ProseMirror")
       .children()
       .each(($el) => elementTypes.push(getElementType($el)))

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,4 +1,5 @@
-import type { EditorView } from "prosemirror-view";
+import { Plugin } from "prosemirror-state";
+import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { embedWrapperTestId } from "../../src/mounters/react/EmbedWrapper";
 import { getNestedViewTestId } from "../../src/mounters/react/NestedEditorView";
 import { docToHtml } from "../../src/prosemirrorSetup";
@@ -58,3 +59,30 @@ export const assertDocHtml = (expectedHtml: string) =>
     );
     expect(expectedHtml).to.equal(actualHtml);
   });
+
+export const addTestDecorationPlugin = new Plugin({
+  props: {
+    decorations: (state) => {
+      const decorateThisPhrase = "deco";
+      const ranges = [] as Array<[number, number]>;
+      state.doc.descendants((node, offset) => {
+        if (node.isLeaf && node.textContent) {
+          const indexOfDeco = node.textContent.indexOf(decorateThisPhrase);
+          if (indexOfDeco !== -1) {
+            ranges.push([
+              indexOfDeco + offset,
+              indexOfDeco + offset + decorateThisPhrase.length,
+            ]);
+          }
+        }
+      });
+
+      return DecorationSet.create(
+        state.doc,
+        ranges.map(([from, to]) =>
+          Decoration.inline(from, to, { class: "TestDecoration" })
+        )
+      );
+    },
+  },
+});

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,0 +1,56 @@
+import type { EditorView } from "prosemirror-view";
+import { embedWrapperTestId } from "../../src/mounters/react/EmbedWrapper";
+import { getNestedViewTestId } from "../../src/mounters/react/NestedEditorView";
+import { docToHtml } from "../../src/prosemirrorSetup";
+
+export const selectDataCy = (id: string) => `[data-cy=${id}]`;
+
+export const getElementType = (element: JQuery) => {
+  if (element.prop("tagName") === "P") {
+    return "paragraph";
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- it's not always truthy.
+  if (element.find(selectDataCy(embedWrapperTestId))[0]) {
+    return "embed";
+  }
+  return "unknown";
+};
+
+export const addEmbed = () => cy.get("#embed").click();
+
+export const typeIntoProsemirror = (content: string, paragraphIndex = 1) =>
+  cy.get(`.ProseMirror p:nth-child(${paragraphIndex})`).type(content);
+
+export const getEmbedField = (fieldName: string, paragraphIndex = 1) =>
+  cy.get(
+    `div${selectDataCy(
+      getNestedViewTestId(fieldName)
+    )} .ProseMirror p:nth-child(${paragraphIndex})`
+  );
+
+export const typeIntoEmbedField = (
+  fieldName: string,
+  content: string,
+  paragraphIndex = 1
+) => getEmbedField(fieldName, paragraphIndex).type(content);
+
+export const getArrayOfBlockElementTypes = () => {
+  // eslint-disable-next-line prefer-const -- it is used.
+  let elementTypes = [] as string[];
+  return new Cypress.Promise((resolve) => {
+    console.log(cy.get("#editor .ProseMirror-menubar-wrapper .ProseMirror"));
+    cy.get("#editor > .ProseMirror-menubar-wrapper > .ProseMirror")
+      .children()
+      .each(($el) => elementTypes.push(getElementType($el)))
+      .then(() => resolve(elementTypes));
+  });
+};
+
+export const assertDocHtml = (expectedHtml: string) =>
+  cy.window().then((win) => {
+    const actualHtml = docToHtml(
+      ((win as unknown) as { view: EditorView }).view.state.doc
+    );
+    expect(expectedHtml).to.equal(actualHtml);
+  });

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -25,6 +25,18 @@ export const typeIntoProsemirror = (content: string) =>
 export const getEmbedField = (fieldName: string) =>
   cy.get(`div${selectDataCy(getNestedViewTestId(fieldName))} .ProseMirror`);
 
+export const getEmbedMenu = (fieldName: string) =>
+  cy.get(
+    `div${selectDataCy(getNestedViewTestId(fieldName))} .ProseMirror-menubar`
+  );
+
+export const getEmbedMenuButton = (fieldName: string, buttonTitle: string) =>
+  cy.get(
+    `div${selectDataCy(
+      getNestedViewTestId(fieldName)
+    )} .ProseMirror-menubar [title="${buttonTitle}"]`
+  );
+
 export const typeIntoEmbedField = (fieldName: string, content: string) =>
   getEmbedField(fieldName).type(content);
 

--- a/cypress/tests/integration/EmbedWrapper.spec.ts
+++ b/cypress/tests/integration/EmbedWrapper.spec.ts
@@ -8,25 +8,21 @@ import {
 } from "../../../src/mounters/react/EmbedWrapper";
 import {
   addEmbed,
-  assertDocHtml,
   getArrayOfBlockElementTypes,
-  getEmbedField,
   selectDataCy,
-  typeIntoEmbedField,
-  typeIntoProsemirror,
 } from "../../helpers/editor";
 
-describe("Element interations", () => {
+describe("EmbedWrapper", () => {
   beforeEach(() => cy.visit("/"));
 
-  describe("Element creation", () => {
+  describe("Embed creation", () => {
     it("should create an element given its DOM specification", () => {
       addEmbed();
       cy.get(selectDataCy(ImageEmbedTestId));
     });
   });
 
-  describe("Element movement", () => {
+  describe("Embed movement", () => {
     it("should move an element down", async () => {
       addEmbed();
       cy.get(selectDataCy(moveDownTestId)).click();
@@ -64,29 +60,6 @@ describe("Element interations", () => {
       cy.get(selectDataCy(removeTestId)).click();
       const elementTypes = await getArrayOfBlockElementTypes();
       expect(elementTypes).to.deep.equal(["paragraph", "paragraph"]);
-    });
-  });
-
-  describe("Element input", () => {
-    it("should accept input", () => {
-      typeIntoProsemirror("{selectall}Text", 1);
-      cy.get(".ProseMirror > p").should("have.text", "Text");
-    });
-
-    it("should accept input in an embed", () => {
-      addEmbed();
-      typeIntoEmbedField("caption", "Caption text");
-      getEmbedField("caption").should("have.text", "Caption text");
-    });
-  });
-
-  describe("Element input content modelling", () => {
-    it("should model an embed field as a node in the document", () => {
-      addEmbed();
-      typeIntoEmbedField("caption", "Caption text");
-      assertDocHtml(
-        `<embed-attrs type="imageEmbed" fields="{&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;src&quot;:&quot;&quot;}" has-errors="false"><div class="imageNative-caption"><p>Caption text</p></div><div class="imageNative-altText"><p></p></div></embed-attrs><p>First paragraph</p><p>Second paragraph</p>`
-      );
     });
   });
 });

--- a/cypress/tests/integration/ImageEmbed.spec.ts
+++ b/cypress/tests/integration/ImageEmbed.spec.ts
@@ -23,7 +23,7 @@ describe("ImageEmbed", () => {
     });
 
     fields.forEach((field) => {
-      it(`should accept input in an embed for the ${field} field`, () => {
+      it(`Field: ${field} – should accept input in an embed`, () => {
         addEmbed();
         const text = `${field} text`;
         typeIntoEmbedField(field, text);
@@ -31,11 +31,13 @@ describe("ImageEmbed", () => {
       });
 
       fieldStyles.forEach((style) => {
-        it("should toggle style of an input in an embed - altText", () => {
+        it(`Field: ${field} – should toggle style of an input in an embed`, () => {
           addEmbed();
           getEmbedMenuButton(field, `Toggle ${style.title}`).click();
           typeIntoEmbedField(field, "Example text");
-          getEmbedField(field).find(style.tag);
+          getEmbedField(field)
+            .find(style.tag)
+            .should("have.text", "Example text");
         });
       });
     });

--- a/cypress/tests/integration/ImageEmbed.spec.ts
+++ b/cypress/tests/integration/ImageEmbed.spec.ts
@@ -30,6 +30,15 @@ describe("ImageEmbed", () => {
         getEmbedField(field).should("have.text", text);
       });
 
+      it(`Field: ${field} – should render decorations passed from the parent editor`, () => {
+        addEmbed();
+        const text = `${field} deco `;
+        typeIntoEmbedField(field, text);
+        getEmbedField(field)
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
       fieldStyles.forEach((style) => {
         it(`Field: ${field} – should toggle style of an input in an embed`, () => {
           addEmbed();

--- a/cypress/tests/integration/ImageEmbed.spec.ts
+++ b/cypress/tests/integration/ImageEmbed.spec.ts
@@ -1,0 +1,41 @@
+import {
+  addEmbed,
+  assertDocHtml,
+  getEmbedField,
+  typeIntoEmbedField,
+  typeIntoProsemirror,
+} from "../../helpers/editor";
+
+describe("ImageEmbed", () => {
+  beforeEach(() => cy.visit("/"));
+
+  describe("Accepting input", () => {
+    it("should accept editor input", () => {
+      typeIntoProsemirror("{selectall}Text");
+      cy.get(".ProseMirror > p").should("have.text", "Text");
+    });
+
+    it("should accept input in an embed - caption", () => {
+      addEmbed();
+      typeIntoEmbedField("caption", "Caption text");
+      getEmbedField("caption").should("have.text", "Caption text");
+    });
+
+    it("should accept input in an embed - altText", () => {
+      addEmbed();
+      typeIntoEmbedField("altText", "Alt text");
+      getEmbedField("altText").should("have.text", "Alt text");
+    });
+  });
+
+  describe("Element input content modelling", () => {
+    it("should model RTE fields as nodes in the document", () => {
+      addEmbed();
+      typeIntoEmbedField("caption", "Caption text");
+      typeIntoEmbedField("altText", "Alt text");
+      assertDocHtml(
+        `<embed-attrs type="imageEmbed" fields="{&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;src&quot;:&quot;&quot;}" has-errors="false"><div class="imageNative-caption"><p>Caption text</p></div><div class="imageNative-altText"><p>Alt text</p></div></embed-attrs><p>First paragraph</p><p>Second paragraph</p>`
+      );
+    });
+  });
+});

--- a/cypress/tests/integration/ImageEmbed.spec.ts
+++ b/cypress/tests/integration/ImageEmbed.spec.ts
@@ -39,6 +39,15 @@ describe("ImageEmbed", () => {
           .should("have.text", "deco");
       });
 
+      it(`Field: ${field} – should map decorations passed from the parent editor correctly when they move`, () => {
+        addEmbed();
+        const text = `${field} deco{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow} more text`;
+        typeIntoEmbedField(field, text);
+        getEmbedField(field)
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
       fieldStyles.forEach((style) => {
         it(`Field: ${field} – should toggle style of an input in an embed`, () => {
           addEmbed();

--- a/cypress/tests/integration/ImageEmbed.spec.ts
+++ b/cypress/tests/integration/ImageEmbed.spec.ts
@@ -2,6 +2,7 @@ import {
   addEmbed,
   assertDocHtml,
   getEmbedField,
+  getEmbedMenuButton,
   typeIntoEmbedField,
   typeIntoProsemirror,
 } from "../../helpers/editor";
@@ -9,22 +10,34 @@ import {
 describe("ImageEmbed", () => {
   beforeEach(() => cy.visit("/"));
 
+  const fields = ["caption", "altText"];
+  const fieldStyles = [
+    { title: "strong style", tag: "strong" },
+    { title: "emphasis", tag: "em" },
+  ];
+
   describe("Accepting input", () => {
     it("should accept editor input", () => {
       typeIntoProsemirror("{selectall}Text");
       cy.get(".ProseMirror > p").should("have.text", "Text");
     });
 
-    it("should accept input in an embed - caption", () => {
-      addEmbed();
-      typeIntoEmbedField("caption", "Caption text");
-      getEmbedField("caption").should("have.text", "Caption text");
-    });
+    fields.forEach((field) => {
+      it(`should accept input in an embed for the ${field} field`, () => {
+        addEmbed();
+        const text = `${field} text`;
+        typeIntoEmbedField(field, text);
+        getEmbedField(field).should("have.text", text);
+      });
 
-    it("should accept input in an embed - altText", () => {
-      addEmbed();
-      typeIntoEmbedField("altText", "Alt text");
-      getEmbedField("altText").should("have.text", "Alt text");
+      fieldStyles.forEach((style) => {
+        it("should toggle style of an input in an embed - altText", () => {
+          addEmbed();
+          getEmbedMenuButton(field, `Toggle ${style.title}`).click();
+          typeIntoEmbedField(field, "Example text");
+          getEmbedField(field).find(style.tag);
+        });
+      });
     });
   });
 

--- a/cypress/tests/integration/element.spec.ts
+++ b/cypress/tests/integration/element.spec.ts
@@ -1,0 +1,92 @@
+import { ImageEmbedTestId } from "../../../src/embeds/image/ImageEmbed";
+import {
+  moveBottomTestId,
+  moveDownTestId,
+  moveTopTestId,
+  moveUpTestId,
+  removeTestId,
+} from "../../../src/mounters/react/EmbedWrapper";
+import {
+  addEmbed,
+  assertDocHtml,
+  getArrayOfBlockElementTypes,
+  getEmbedField,
+  selectDataCy,
+  typeIntoEmbedField,
+  typeIntoProsemirror,
+} from "../../helpers/editor";
+
+describe("Element interations", () => {
+  beforeEach(() => cy.visit("/"));
+
+  describe("Element creation", () => {
+    it("should create an element given its DOM specification", () => {
+      addEmbed();
+      cy.get(selectDataCy(ImageEmbedTestId));
+    });
+  });
+
+  describe("Element movement", () => {
+    it("should move an element down", async () => {
+      addEmbed();
+      cy.get(selectDataCy(moveDownTestId)).click();
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal(["paragraph", "embed", "paragraph"]);
+    });
+
+    it("should move an element to the bottom", async () => {
+      addEmbed();
+      cy.get(selectDataCy(moveBottomTestId)).click();
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal(["paragraph", "paragraph", "embed"]);
+    });
+
+    it("should move an element up", async () => {
+      addEmbed();
+      cy.get(selectDataCy(moveDownTestId)).click();
+      cy.get(selectDataCy(moveDownTestId)).click();
+      cy.get(selectDataCy(moveUpTestId)).click();
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal(["paragraph", "embed", "paragraph"]);
+    });
+
+    it("should move an element to the top", async () => {
+      addEmbed();
+      cy.get(selectDataCy(moveDownTestId)).click();
+      cy.get(selectDataCy(moveDownTestId)).click();
+      cy.get(selectDataCy(moveTopTestId)).click();
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal(["embed", "paragraph", "paragraph"]);
+    });
+
+    it("should remove an element", async () => {
+      addEmbed();
+      cy.get(selectDataCy(removeTestId)).click();
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal(["paragraph", "paragraph"]);
+    });
+  });
+
+  describe("Element input", () => {
+    it("should accept input", () => {
+      typeIntoProsemirror("{selectall}Text", 1);
+      cy.get(".ProseMirror > p").should("have.text", "Text");
+    });
+
+    it("should accept input in an embed", () => {
+      addEmbed();
+      typeIntoEmbedField("caption", "Caption text");
+      getEmbedField("caption").should("have.text", "Caption text");
+    });
+  });
+
+  describe("Element input content modelling", () => {
+    it("should model an embed field as a node in the document", () => {
+      addEmbed();
+      typeIntoEmbedField("caption", "Caption text");
+      assertDocHtml(
+        `<embed-attrs type="imageEmbed" fields="{&quot;alt&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;src&quot;:&quot;&quot;}" has-errors="false"><div class="imageNative-caption"><p>Caption text</p></div><div class="imageNative-altText"><p></p></div></embed-attrs><p>First paragraph</p><p>Second paragraph</p>`
+      );
+    });
+  });
+});

--- a/dist/index.html
+++ b/dist/index.html
@@ -21,7 +21,13 @@
   h6 {
     font-weight: 400;
     font-family: 'DE5 Display Egyptian SemiBold'
-  }</style>
+  }
+
+  .TestDecoration {
+    background-color: peachpuff;
+  }
+
+  </style>
 </head>
 
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -39,22 +39,11 @@
 </head>
 
 <body>
-  <div id="editor">
-  </div>
+  <div id="editor"></div>
   <div id="content" style="display: none;">
-    <h3>Hello ProseMirror</h3>
-
-    <p>This is editable text. You can focus it and start typing.</p>
-    <embed-attrs url="test">
-    <p>To apply styling, you can select a piece of text and manipulate its styling from the menu. The basic schema supports
-      <em>emphasis</em>,
-      <strong>strong text
-      </strong>,
-      <a href="http://marijnhaverbeke.nl/blog">links</a>,
-      <code>code
-        font</code>, and images.
-    </p>
-  </embed-attrs></div>
+    <p>First paragraph</p>
+    <p>Second paragraph</p>
+  </div>
   <script src="bundle.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -40,21 +40,9 @@
 </head>
 
 <body>
-  <div id="editor">
-  </div>
+  <div id="editor"></div>
   <div id="content" style="display: none;">
-    <h3>Hello ProseMirror</h3>
-
-    <p>This is editable text. You can focus it and start typing.</p>
-    <embed-attrs url="test" />
-    <p>To apply styling, you can select a piece of text and manipulate its styling from the menu. The basic schema supports
-      <em>emphasis</em>,
-      <strong>strong text
-      </strong>,
-      <a href="http://marijnhaverbeke.nl/blog">links</a>,
-      <code>code
-        font</code>, and images.
-    </p>
+    <p>An example document.</p>
   </div>
   <script src="src/index.ts"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/prosemirror-schema-basic": "^1.0.1",
     "@types/prosemirror-state": "^1.2.6",
     "@types/prosemirror-transform": "^1.1.0",
-    "@types/prosemirror-view": "^1.17.1",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "webpack serve --open",
     "test": "cypress open",
-    "ci": "yarn lint && cypress run",
+    "ci": "yarn lint && webpack serve & (wait-on http://localhost:7890 && cypress run)",
+    "postci": "kill $(lsof -t -i:7890)",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
@@ -50,6 +51,7 @@
     "prettier": "^2.2.1",
     "ts-loader": "^8.0.17",
     "typescript": "^4.2.4",
+    "wait-on": "^5.3.0",
     "webpack": "^5.24.4",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prosemirror-schema-basic": "^1.0.0",
     "prosemirror-state": "^1.3.4",
     "prosemirror-transform": "^1.1.3",
-    "prosemirror-view": "^1.18.0",
+    "prosemirror-view": "^1.18.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/src/baseSchema.ts
+++ b/src/baseSchema.ts
@@ -37,7 +37,7 @@ export const baseEmbedSchema: NodeSpec = {
         fields: JSON.stringify(node.attrs.fields),
         "has-errors": JSON.stringify(node.attrs.hasErrors),
       },
-      0
+      0,
     ],
     parseDOM: [
       {

--- a/src/baseSchema.ts
+++ b/src/baseSchema.ts
@@ -18,7 +18,8 @@ export const baseEmbedSchema: NodeSpec = {
     parseDOM: [{ tag: "div" }],
   },
   imageEmbed: {
-    group: "caption altText",
+    group: "block",
+    content: "caption altText",
     attrs: {
       type: {},
       fields: {

--- a/src/baseSchema.ts
+++ b/src/baseSchema.ts
@@ -3,7 +3,7 @@ import type { Node, NodeSpec } from "prosemirror-model";
 export const baseEmbedSchema: NodeSpec = {
   caption: {
     group: "block",
-    content: "paragraph",
+    content: "inline*",
     toDOM() {
       return ["div", { class: "imageNative-caption" }, 0];
     },
@@ -11,7 +11,7 @@ export const baseEmbedSchema: NodeSpec = {
   },
   altText: {
     group: "block",
-    content: "paragraph",
+    content: "inline*",
     toDOM() {
       return ["div", { class: "imageNative-altText" }, 0];
     },

--- a/src/baseSchema.ts
+++ b/src/baseSchema.ts
@@ -1,0 +1,58 @@
+import type { Node, NodeSpec } from "prosemirror-model";
+
+export const baseEmbedSchema: NodeSpec = {
+  caption: {
+    group: "block",
+    content: "paragraph",
+    toDOM() {
+      return ["div", { class: "imageNative-caption" }, 0];
+    },
+    parseDOM: [{ tag: "div" }],
+  },
+  altText: {
+    group: "block",
+    content: "paragraph",
+    toDOM() {
+      return ["div", { class: "imageNative-altText" }, 0];
+    },
+    parseDOM: [{ tag: "div" }],
+  },
+  imageEmbed: {
+    group: "caption altText",
+    attrs: {
+      type: {},
+      fields: {
+        default: {},
+      },
+      hasErrors: {
+        default: false,
+      },
+    },
+    draggable: false,
+    toDOM: (node: Node) => [
+      "embed-attrs",
+      {
+        type: node.attrs.type as string,
+        fields: JSON.stringify(node.attrs.fields),
+        "has-errors": JSON.stringify(node.attrs.hasErrors),
+      },
+    ],
+    parseDOM: [
+      {
+        tag: "embed-attrs",
+        getAttrs: (dom: Element) => {
+          if (typeof dom === "string") {
+            return;
+          }
+          const hasErrorAttr = dom.getAttribute("has-errors");
+          console.log(dom.getAttribute("fields"));
+          return {
+            type: dom.getAttribute("type"),
+            fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
+            hasErrors: hasErrorAttr && hasErrorAttr !== "false",
+          };
+        },
+      },
+    ],
+  },
+};

--- a/src/baseSchema.ts
+++ b/src/baseSchema.ts
@@ -3,7 +3,7 @@ import type { Node, NodeSpec } from "prosemirror-model";
 export const baseEmbedSchema: NodeSpec = {
   caption: {
     group: "block",
-    content: "inline*",
+    content: "paragraph",
     toDOM() {
       return ["div", { class: "imageNative-caption" }, 0];
     },
@@ -11,7 +11,7 @@ export const baseEmbedSchema: NodeSpec = {
   },
   altText: {
     group: "block",
-    content: "inline*",
+    content: "paragraph",
     toDOM() {
       return ["div", { class: "imageNative-altText" }, 0];
     },

--- a/src/baseSchema.ts
+++ b/src/baseSchema.ts
@@ -37,6 +37,7 @@ export const baseEmbedSchema: NodeSpec = {
         fields: JSON.stringify(node.attrs.fields),
         "has-errors": JSON.stringify(node.attrs.hasErrors),
       },
+      0
     ],
     parseDOM: [
       {
@@ -46,7 +47,7 @@ export const baseEmbedSchema: NodeSpec = {
             return;
           }
           const hasErrorAttr = dom.getAttribute("has-errors");
-          console.log(dom.getAttribute("fields"));
+
           return {
             type: dom.getAttribute("type"),
             fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,

--- a/src/declarations/prosemirror-example-setup.d.ts
+++ b/src/declarations/prosemirror-example-setup.d.ts
@@ -1,5 +1,6 @@
-declare module "prosemirror-keymap" {
+declare module "prosemirror-example-setup" {
+  import type { Schema } from "prosemirror-model";
   import type { Plugin } from "prosemirror-state";
 
-  const keymap: (map: Record<string, () => void>) => Plugin;
+  const exampleSetup: ({ schema }: { schema: Schema }) => Plugin[];
 }

--- a/src/declarations/prosemirror-keymap.d.ts
+++ b/src/declarations/prosemirror-keymap.d.ts
@@ -1,6 +1,5 @@
-declare module "prosemirror-example-setup" {
-  import type { Schema } from "prosemirror-model";
+declare module "prosemirror-keymap" {
   import type { Plugin } from "prosemirror-state";
 
-  const exampleSetup: ({ schema }: { schema: Schema }) => Plugin[];
+  const keymap: (map: Record<string, () => void>) => Plugin;
 }

--- a/src/declarations/prosemirror-view.d.ts
+++ b/src/declarations/prosemirror-view.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-indexed-object-style,@typescript-eslint/ban-types --
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style,@typescript-eslint/ban-types,@typescript-eslint/no-explicit-any --
  * These are temporary type definitions to accommodate 1.18, and will be replaced once they're added to DefinitelyType.
  */
 

--- a/src/declarations/prosemirror-view.d.ts
+++ b/src/declarations/prosemirror-view.d.ts
@@ -1,0 +1,860 @@
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style,@typescript-eslint/ban-types --
+ * These are temporary type definitions to accommodate 1.18, and will be replaced once they're added to DefinitelyType.
+ */
+
+// Type definitions for prosemirror-view 1.17, modified in this project to accommodate 1.18
+// Project: https://github.com/ProseMirror/prosemirror-view
+// Definitions by: Bradley Ayers <https://github.com/bradleyayers>
+//                 David Hahn <https://github.com/davidka>
+//                 Tim Baumann <https://github.com/timjb>
+//                 Patrick Simmelbauer <https://github.com/patsimm>
+//                 Ifiok Jr. <https://github.com/ifiokjr>
+//                 Mike Morearty <https://github.com/mmorearty>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+declare module "prosemirror-view" {
+  import type {
+    DOMParser,
+    DOMSerializer,
+    Mark,
+    Node as ProsemirrorNode,
+    ResolvedPos,
+    Schema,
+    Slice,
+  } from "prosemirror-model";
+  import type { EditorState, Selection, Transaction } from "prosemirror-state";
+  import type { Mapping } from "prosemirror-transform";
+
+  // Exported for testing
+  export function __serializeForClipboard<S extends Schema = any>(
+    view: EditorView<S>,
+    slice: Slice<S>
+  ): { dom: HTMLElement; text: string };
+  export function __parseFromClipboard<S extends Schema = any>(
+    view: EditorView<S>,
+    text: string,
+    html: string,
+    plainText: boolean,
+    $context: ResolvedPos<S>
+  ): Slice<S>;
+  export function __endComposition(
+    view: EditorView,
+    forceUpdate?: boolean
+  ): boolean;
+
+  /**
+   * The `spec` for a widget decoration
+   */
+  export interface WidgetDecorationSpec {
+    /**
+     * Controls which side of the document position this widget is
+     * associated with. When negative, it is drawn before a cursor
+     * at its position, and content inserted at that position ends
+     * up after the widget. When zero (the default) or positive, the
+     * widget is drawn after the cursor and content inserted there
+     * ends up before the widget.
+     *
+     * When there are multiple widgets at a given position, their
+     * `side` values determine the order in which they appear. Those
+     * with lower values appear first. The ordering of widgets with
+     * the same `side` value is unspecified.
+     *
+     * When `marks` is null, `side` also determines the marks that
+     * the widget is wrapped in—those of the node before when
+     * negative, those of the node after when positive.
+     */
+    side?: number | null;
+    /**
+     * The precise set of marks to draw around the widget.
+     */
+    marks?: Mark[] | null;
+    /**
+     * Can be used to control which DOM events, when they bubble out
+     * of this widget, the editor view should ignore.
+     */
+    stopEvent?: ((event: Event) => boolean) | null;
+    /**
+     * When comparing decorations of this type (in order to decide
+     * whether it needs to be redrawn), ProseMirror will by default
+     * compare the widget DOM node by identity. If you pass a key,
+     * that key will be compared instead, which can be useful when
+     * you generate decorations on the fly and don't want to store
+     * and reuse DOM nodes. Make sure that any widgets with the same
+     * key are interchangeable—if widgets differ in, for example,
+     * the behavior of some event handler, they should get
+     * different keys.
+     */
+    key?: string | null;
+  }
+  /**
+   * The `spec` for the inline decoration.
+   */
+  export interface InlineDecorationSpec {
+    /**
+     * Determines how the left side of the decoration is
+     * [mapped](#transform.Position_Mapping) when content is
+     * inserted directly at that position. By default, the decoration
+     * won't include the new content, but you can set this to `true`
+     * to make it inclusive.
+     */
+    inclusiveStart?: boolean | null;
+    /**
+     * Determines how the right side of the decoration is mapped.
+     */
+    inclusiveEnd?: boolean | null;
+  }
+  /**
+   * Decoration objects can be provided to the view through the
+   * [`decorations` prop](#view.EditorProps.decorations). They come in
+   * several variants—see the static members of this class for details.
+   */
+  export class Decoration<T extends object = { [key: string]: any }> {
+    /**
+     * The start position of the decoration.
+     */
+    from: number;
+    /**
+     * The end position. Will be the same as `from` for [widget
+     * decorations](#view.Decoration^widget).
+     */
+    to: number;
+    /**
+     * The spec provided when creating this decoration. Can be useful
+     * if you've stored extra information in that object.
+     */
+    spec: T;
+    /**
+     * Creates a widget decoration, which is a DOM node that's shown in
+     * the document at the given position. It is recommended that you
+     * delay rendering the widget by passing a function that will be
+     * called when the widget is actually drawn in a view, but you can
+     * also directly pass a DOM node. getPos can be used to find the
+     * widget's current document position.
+     */
+    static widget<T extends object = { [key: string]: any }>(
+      pos: number,
+      toDOM: ((view: EditorView, getPos: () => number) => Node) | Node,
+      spec?: T & WidgetDecorationSpec
+    ): Decoration<T & WidgetDecorationSpec>;
+    /**
+     * Creates an inline decoration, which adds the given attributes to
+     * each inline node between `from` and `to`.
+     */
+    static inline<T extends object = { [key: string]: any }>(
+      from: number,
+      to: number,
+      attrs: DecorationAttrs,
+      spec?: T & InlineDecorationSpec
+    ): Decoration<T & InlineDecorationSpec>;
+    /**
+     * Creates a node decoration. `from` and `to` should point precisely
+     * before and after a node in the document. That node, and only that
+     * node, will receive the given attributes.
+     */
+    static node<T extends object = { [key: string]: any }>(
+      from: number,
+      to: number,
+      attrs: DecorationAttrs,
+      spec?: T
+    ): Decoration<T>;
+  }
+  /**
+   * A set of attributes to add to a decorated node. Most properties
+   * simply directly correspond to DOM attributes of the same name,
+   * which will be set to the property's value. These are exceptions:
+   */
+  export interface DecorationAttrs {
+    /**
+     * A CSS class name or a space-separated set of class names to be
+     * _added_ to the classes that the node already had.
+     */
+    class?: string | null;
+    /**
+     * A string of CSS to be _added_ to the node's existing `style` property.
+     */
+    style?: string | null;
+    /**
+     * When non-null, the target node is wrapped in a DOM element of
+     * this type (and the other attributes are applied to this element).
+     */
+    nodeName?: string | null;
+    /**
+     * Specify additional attrs that will be mapped directly to the
+     * target node's DOM attributes.
+     */
+    [key: string]: string | null | undefined;
+  }
+  /**
+   * A collection of [decorations](#view.Decoration), organized in
+   * such a way that the drawing algorithm can efficiently use and
+   * compare them. This is a persistent data structure—it is not
+   * modified, updates create a new value.
+   */
+  export class DecorationSet<S extends Schema = any> {
+    /**
+     * Find all decorations in this set which touch the given range
+     * (including decorations that start or end directly at the
+     * boundaries) and match the given predicate on their spec. When
+     * `start` and `end` are omitted, all decorations in the set are
+     * considered. When `predicate` isn't given, all decorations are
+     * assumed to match.
+     */
+    find(
+      start?: number,
+      end?: number,
+      predicate?: (spec: { [key: string]: any }) => boolean
+    ): Decoration[];
+    /**
+     * Map the set of decorations in response to a change in the
+     * document.
+     */
+    map(
+      mapping: Mapping,
+      doc: ProsemirrorNode<S>,
+      options?: {
+        onRemove?: ((decorationSpec: { [key: string]: any }) => void) | null;
+      }
+    ): DecorationSet<S>;
+    /**
+     * Add the given array of decorations to the ones in the set,
+     * producing a new set. Needs access to the current document to
+     * create the appropriate tree structure.
+     */
+    add(doc: ProsemirrorNode<S>, decorations: Decoration[]): DecorationSet<S>;
+    /**
+     * Create a new set that contains the decorations in this set, minus
+     * the ones in the given array.
+     */
+    remove(decorations: Decoration[]): DecorationSet<S>;
+    /**
+     * Create a set of decorations, using the structure of the given
+     * document.
+     */
+    static create<S extends Schema = any>(
+      doc: ProsemirrorNode<S>,
+      decorations: Decoration[]
+    ): DecorationSet<S>;
+    /**
+     * The empty set of decorations.
+     */
+    static empty: DecorationSet;
+  }
+  /**
+   * An editor view manages the DOM structure that represents an
+   * editable document. Its state and behavior are determined by its
+   * [props](#view.DirectEditorProps).
+   */
+  export class EditorView<S extends Schema = any> {
+    /**
+     * Create a view. `place` may be a DOM node that the editor should
+     * be appended to, a function that will place it into the document,
+     * or an object whose `mount` property holds the node to use as the
+     * document container. If it is `null`, the editor will not be added
+     * to the document.
+     */
+    constructor(
+      place: Node | ((p: Node) => void) | { mount: Node } | undefined,
+      props: DirectEditorProps<S>
+    );
+    /**
+     * The view's current [state](#state.EditorState).
+     */
+    state: EditorState<S>;
+    /**
+     * An editable DOM node containing the document. (You probably
+     * should not directly interfere with its content.)
+     */
+    dom: Element;
+    /**
+     * Indicates whether the editor is currently [editable](#view.EditorProps.editable).
+     */
+    editable: boolean;
+    /**
+     * When editor content is being dragged, this object contains
+     * information about the dragged slice and whether it is being
+     * copied or moved. At any other time, it is null.
+     */
+    dragging?: { slice: Slice<S>; move: boolean } | null;
+    /**
+     * Holds true when a composition is active.
+     */
+    composing: boolean;
+    /**
+     * The view's current [props](#view.EditorProps).
+     */
+    props: DirectEditorProps<S>;
+    /**
+     * Update the view's props. Will immediately cause an update to
+     * the DOM.
+     */
+    update(props: DirectEditorProps<S>): void;
+    /**
+     * Update the view by updating existing props object with the object
+     * given as argument. Equivalent to `view.update(Object.assign({},
+     * view.props, props))`.
+     */
+    setProps(props: Partial<DirectEditorProps<S>>): void;
+    /**
+     * Update the editor's `state` prop, without touching any of the
+     * other props.
+     */
+    updateState(state: EditorState<S>): void;
+    /**
+     * Goes over the values of a prop, first those provided directly,
+     * then those from plugins (in order), and calls `f` every time a
+     * non-undefined value is found. When `f` returns a truthy value,
+     * that is immediately returned. When `f` isn't provided, it is
+     * treated as the identity function (the prop value is returned
+     * directly).
+     */
+    someProp(propName: string, f?: (prop: any) => any): any;
+    /**
+     * Query whether the view has focus.
+     */
+    hasFocus(): boolean;
+    /**
+     * Focus the editor.
+     */
+    focus(): void;
+    /**
+     * Get the document root in which the editor exists. This will
+     * usually be the top-level `document`, but might be a [shadow
+     * DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Shadow_DOM)
+     * root if the editor is inside one.
+     */
+    root: Document | DocumentFragment;
+    /**
+     * Given a pair of viewport coordinates, return the document
+     * position that corresponds to them. May return null if the given
+     * coordinates aren't inside of the editor. When an object is
+     * returned, its `pos` property is the position nearest to the
+     * coordinates, and its `inside` property holds the position of the
+     * inner node that the position falls inside of, or -1 if it is at
+     * the top level, not in any node.
+     */
+    posAtCoords(coords: {
+      left: number;
+      top: number;
+    }): { pos: number; inside: number } | null | undefined;
+    /**
+     * Returns the viewport rectangle at a given document position.
+     * `left` and `right` will be the same number, as this returns a
+     * flat cursor-ish rectangle. If the position is between two things
+     * that aren't directly adjacent, `side` determines which element is
+     * used. When < 0, the element before the position is used,
+     * otherwise the element after.
+     */
+    coordsAtPos(
+      pos: number,
+      side?: number
+    ): { left: number; right: number; top: number; bottom: number };
+    /**
+     * Find the DOM position that corresponds to the given document
+     * position. When `side` is negative, find the position as close as
+     * possible to the content before the position. When positive,
+     * prefer positions close to the content after the position. When
+     * zero, prefer as shallow a position as possible.
+     *
+     * Note that you should **not** mutate the editor's internal DOM,
+     * only inspect it (and even that is usually not necessary).
+     */
+    domAtPos(pos: number, side?: number): { node: Node; offset: number };
+    /**
+     * Find the DOM node that represents the document node after the
+     * given position. May return null when the position doesn't point
+     * in front of a node or if the node is inside an opaque node view.
+     *
+     * This is intended to be able to call things like getBoundingClientRect
+     * on that DOM node. Do not mutate the editor DOM directly, or add
+     * styling this way, since that will be immediately overriden by the
+     * editor as it redraws the node.
+     */
+    nodeDOM(pos: number): Node | null | undefined;
+    /**
+     * Find the document position that corresponds to a given DOM position.
+     * (Whenever possible, it is preferable to inspect the document structure
+     * directly, rather than poking around in the DOM, but sometimes—for
+     * example when interpreting an event target—you don't have a choice.)
+     *
+     * The bias (default: -1) parameter can be used to influence which side of
+     * a DOM node to use when the position is inside a leaf node.
+     */
+    posAtDOM(node: Node, offset: number, bias?: number | null): number;
+    /**
+     * Find out whether the selection is at the end of a textblock when
+     * moving in a given direction. When, for example, given `"left"`,
+     * it will return true if moving left from the current cursor
+     * position would leave that position's parent textblock. Will apply
+     * to the view's current state by default, but it is possible to
+     * pass a different state.
+     */
+    endOfTextblock(
+      dir: "up" | "down" | "left" | "right" | "forward" | "backward",
+      state?: EditorState<S>
+    ): boolean;
+    /**
+     * Removes the editor from the DOM and destroys all [node
+     * views](#view.NodeView).
+     */
+    destroy(): void;
+    /**
+     * Dispatch a transaction. Will call
+     * [`dispatchTransaction`](#view.DirectEditorProps.dispatchTransaction)
+     * when given, and otherwise defaults to applying the transaction to
+     * the current state and calling
+     * [`updateState`](#view.EditorView.updateState) with the result.
+     * This method is bound to the view instance, so that it can be
+     * easily passed around.
+     */
+    dispatch(tr: Transaction<S>): void;
+  }
+  /**
+   * Props are configuration values that can be passed to an editor view
+   * or included in a plugin. This interface lists the supported props.
+   *
+   * The various event-handling functions may all return `true` to
+   * indicate that they handled the given event. The view will then take
+   * care to call `preventDefault` on the event, except with
+   * `handleDOMEvents`, where the handler itself is responsible for that.
+   *
+   * How a prop is resolved depends on the prop. Handler functions are
+   * called one at a time, starting with the base props and then
+   * searching through the plugins (in order of appearance) until one of
+   * them returns true. For some props, the first plugin that yields a
+   * value gets precedence.
+   */
+  export interface EditorProps<ThisT = unknown, S extends Schema = any> {
+    /**
+     * Can be an object mapping DOM event type names to functions that
+     * handle them. Such functions will be called before any handling
+     * ProseMirror does of events fired on the editable DOM element.
+     * Contrary to the other event handling props, when returning true
+     * from such a function, you are responsible for calling
+     * `preventDefault` yourself (or not, if you want to allow the
+     * default behavior).
+     */
+    handleDOMEvents?: HandleDOMEventsProp<ThisT, S> | null;
+    /**
+     * Called when the editor receives a `keydown` event.
+     */
+    handleKeyDown?:
+      | ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean)
+      | null;
+    /**
+     * Handler for `keypress` events.
+     */
+    handleKeyPress?:
+      | ((this: ThisT, view: EditorView<S>, event: KeyboardEvent) => boolean)
+      | null;
+    /**
+     * Whenever the user directly input text, this handler is called
+     * before the input is applied. If it returns `true`, the default
+     * behavior of actually inserting the text is suppressed.
+     */
+    handleTextInput?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          from: number,
+          to: number,
+          text: string
+        ) => boolean)
+      | null;
+    /**
+     * Called for each node around a click, from the inside out. The
+     * `direct` flag will be true for the inner node.
+     */
+    handleClickOn?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          pos: number,
+          node: ProsemirrorNode<S>,
+          nodePos: number,
+          event: MouseEvent,
+          direct: boolean
+        ) => boolean)
+      | null;
+    /**
+     * Called when the editor is clicked, after `handleClickOn` handlers
+     * have been called.
+     */
+    handleClick?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          pos: number,
+          event: MouseEvent
+        ) => boolean)
+      | null;
+    /**
+     * Called for each node around a double click.
+     */
+    handleDoubleClickOn?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          pos: number,
+          node: ProsemirrorNode<S>,
+          nodePos: number,
+          event: MouseEvent,
+          direct: boolean
+        ) => boolean)
+      | null;
+    /**
+     * Called when the editor is double-clicked, after `handleDoubleClickOn`.
+     */
+    handleDoubleClick?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          pos: number,
+          event: MouseEvent
+        ) => boolean)
+      | null;
+    /**
+     * Called for each node around a triple click.
+     */
+    handleTripleClickOn?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          pos: number,
+          node: ProsemirrorNode<S>,
+          nodePos: number,
+          event: MouseEvent,
+          direct: boolean
+        ) => boolean)
+      | null;
+    /**
+     * Called when the editor is triple-clicked, after `handleTripleClickOn`.
+     */
+    handleTripleClick?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          pos: number,
+          event: MouseEvent
+        ) => boolean)
+      | null;
+    /**
+     * Can be used to override the behavior of pasting. `slice` is the
+     * pasted content parsed by the editor, but you can directly access
+     * the event to get at the raw content.
+     */
+    handlePaste?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          event: ClipboardEvent,
+          slice: Slice<S>
+        ) => boolean)
+      | null;
+    /**
+     * Called when something is dropped on the editor. `moved` will be
+     * true if this drop moves from the current selection (which should
+     * thus be deleted).
+     */
+    handleDrop?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          event: Event,
+          slice: Slice<S>,
+          moved: boolean
+        ) => boolean)
+      | null;
+    /**
+     * Called when the view, after updating its state, tries to scroll
+     * the selection into view. A handler function may return false to
+     * indicate that it did not handle the scrolling and further
+     * handlers or the default behavior should be tried.
+     */
+    handleScrollToSelection?:
+      | ((this: ThisT, view: EditorView<S>) => boolean)
+      | null;
+    /**
+     * Can be used to override the way a selection is created when
+     * reading a DOM selection between the given anchor and head.
+     */
+    createSelectionBetween?:
+      | ((
+          this: ThisT,
+          view: EditorView<S>,
+          anchor: ResolvedPos<S>,
+          head: ResolvedPos<S>
+        ) => Selection<S> | null | undefined)
+      | null;
+    /**
+     * The [parser](#model.DOMParser) to use when reading editor changes
+     * from the DOM. Defaults to calling
+     * [`DOMParser.fromSchema`](#model.DOMParser^fromSchema) on the
+     * editor's schema.
+     */
+    domParser?: DOMParser<S> | null;
+    /**
+     * Can be used to transform pasted HTML text, _before_ it is parsed,
+     * for example to clean it up.
+     */
+    transformPastedHTML?: ((this: ThisT, html: string) => string) | null;
+    /**
+     * The [parser](#model.DOMParser) to use when reading content from
+     * the clipboard. When not given, the value of the
+     * [`domParser`](#view.EditorProps.domParser) prop is used.
+     */
+    clipboardParser?: DOMParser<S> | null;
+    /**
+     * Transform pasted plain text. The `plain` flag will be true when
+     * the text is pasted as plain text.
+     */
+    transformPastedText?:
+      | ((this: ThisT, text: string, plain: boolean) => string)
+      | null;
+    /**
+     * A function to parse text from the clipboard into a document
+     * slice. Called after
+     * [`transformPastedText`](#view.EditorProps.transformPastedText).
+     * The default behavior is to split the text into lines, wrap them
+     * in `<p>` tags, and call
+     * [`clipboardParser`](#view.EditorProps.clipboardParser) on it.
+     * The `plain` flag will be true when the text is pasted as plain
+     * text.
+     */
+    clipboardTextParser?:
+      | ((
+          this: ThisT,
+          text: string,
+          $context: ResolvedPos<S>,
+          plain: boolean
+        ) => Slice<S>)
+      | null;
+    /**
+     * Can be used to transform pasted content before it is applied to
+     * the document.
+     */
+    transformPasted?: ((this: ThisT, p: Slice<S>) => Slice<S>) | null;
+    /**
+     * Allows you to pass custom rendering and behavior logic for nodes
+     * and marks. Should map node and mark names to constructor
+     * functions that produce a [`NodeView`](#view.NodeView) object
+     * implementing the node's display behavior. For nodes, the third
+     * argument `getPos` is a function that can be called to get the
+     * node's current position, which can be useful when creating
+     * transactions to update it. For marks, the third argument is a
+     * boolean that indicates whether the mark's content is inline.
+     *
+     * `decorations` is an array of node or inline decorations that are
+     * active around the node. They are automatically drawn in the
+     * normal way, and you will usually just want to ignore this, but
+     * they can also be used as a way to provide context information to
+     * the node view without adding it to the document itself.
+     */
+    nodeViews?: {
+      [name: string]: (
+        node: ProsemirrorNode<S>,
+        view: EditorView<S>,
+        getPos: (() => number) | boolean,
+        decorations: Decoration[],
+        innerDecos: DecorationSet | Decoration[]
+      ) => NodeView<S>;
+    } | null;
+    /**
+     * The DOM serializer to use when putting content onto the
+     * clipboard. If not given, the result of
+     * [`DOMSerializer.fromSchema`](#model.DOMSerializer^fromSchema)
+     * will be used.
+     */
+    clipboardSerializer?: DOMSerializer<S> | null;
+    /**
+     * A function that will be called to get the text for the current
+     * selection when copying text to the clipboard. By default, the
+     * editor will use [`textBetween`](#model.Node.textBetween) on the
+     * selected range.
+     */
+    clipboardTextSerializer?: ((this: ThisT, p: Slice<S>) => string) | null;
+    /**
+     * A set of [document decorations](#view.Decoration) to show in the
+     * view.
+     */
+    decorations?:
+      | ((
+          this: ThisT,
+          state: EditorState<S>
+        ) => DecorationSet<S> | null | undefined)
+      | null;
+    /**
+     * When this returns false, the content of the view is not directly
+     * editable.
+     */
+    editable?: ((this: ThisT, state: EditorState<S>) => boolean) | null;
+    /**
+     * Control the DOM attributes of the editable element. May be either
+     * an object or a function going from an editor state to an object.
+     * By default, the element will get a class `"ProseMirror"`, and
+     * will have its `contentEditable` attribute determined by the
+     * [`editable` prop](#view.EditorProps.editable). Additional classes
+     * provided here will be added to the class. For other attributes,
+     * the value provided first (as in
+     * [`someProp`](#view.EditorView.someProp)) will be used.
+     */
+    attributes?:
+      | { [name: string]: string }
+      | ((
+          this: ThisT,
+          p: EditorState<S>
+        ) => { [name: string]: string } | null | undefined | void)
+      | null;
+    /**
+     * Determines the distance (in pixels) between the cursor and the
+     * end of the visible viewport at which point, when scrolling the
+     * cursor into view, scrolling takes place. Defaults to 0.
+     */
+    scrollThreshold?:
+      | number
+      | { top: number; right: number; bottom: number; left: number }
+      | null;
+    /**
+     * Determines the extra space (in pixels) that is left above or
+     * below the cursor when it is scrolled into view. Defaults to 5.
+     */
+    scrollMargin?:
+      | number
+      | { top: number; right: number; bottom: number; left: number }
+      | null;
+  }
+  /**
+   * A mapping of dom events.
+   */
+  export type HandleDOMEventsProp<
+    ThisT = unknown,
+    S extends Schema = any
+  > = Partial<
+    {
+      [K in keyof DocumentEventMap]: (
+        this: ThisT,
+        view: EditorView<S>,
+        event: DocumentEventMap[K]
+      ) => boolean;
+    }
+  > & {
+    [key: string]: (this: ThisT, view: EditorView<S>, event: any) => boolean;
+  };
+  /**
+   * The props object given directly to the editor view supports two
+   * fields that can't be used in plugins:
+   */
+  export interface DirectEditorProps<S extends Schema = any>
+    extends EditorProps<unknown, S> {
+    /**
+     * The current state of the editor.
+     */
+    state: EditorState<S>;
+    /**
+     * The callback over which to send transactions (state updates)
+     * produced by the view. If you specify this, you probably want to
+     * make sure this ends up calling the view's
+     * [`updateState`](#view.EditorView.updateState) method with a new
+     * state that has the transaction
+     * [applied](#state.EditorState.apply). The callback will be bound to have
+     * the view instance as its `this` binding.
+     */
+    dispatchTransaction?:
+      | ((this: EditorView<S>, tr: Transaction<S>) => void)
+      | null;
+  }
+  /**
+   * By default, document nodes are rendered using the result of the
+   * [`toDOM`](#model.NodeSpec.toDOM) method of their spec, and managed
+   * entirely by the editor. For some use cases, such as embedded
+   * node-specific editing interfaces, you want more control over
+   * the behavior of a node's in-editor representation, and need to
+   * [define](#view.EditorProps.nodeViews) a custom node view.
+   *
+   * Objects returned as node views must conform to this interface.
+   */
+  export interface NodeView<S extends Schema = any> {
+    /**
+     * The outer DOM node that represents the document node. When not
+     * given, the default strategy is used to create a DOM node.
+     */
+    dom?: Node | null;
+    /**
+     * The DOM node that should hold the node's content. Only meaningful
+     * if the node view also defines a `dom` property and if its node
+     * type is not a leaf node type. When this is present, ProseMirror
+     * will take care of rendering the node's children into it. When it
+     * is not present, the node view itself is responsible for rendering
+     * (or deciding not to render) its child nodes.
+     */
+    contentDOM?: Node | null;
+    /**
+     * When given, this will be called when the view is updating itself.
+     * It will be given a node (possibly of a different type), and an
+     * array of active decorations (which are automatically drawn, and
+     * the node view may ignore if it isn't interested in them), and
+     * should return true if it was able to update to that node, and
+     * false otherwise. If the node view has a `contentDOM` property (or
+     * no `dom` property), updating its child nodes will be handled by
+     * ProseMirror.
+     */
+    update?:
+      | ((
+          node: ProsemirrorNode<S>,
+          decorations: Decoration[],
+          innerDecos: DecorationSet | Decoration[]
+        ) => boolean)
+      | null;
+    /**
+     * Can be used to override the way the node's selected status (as a
+     * node selection) is displayed.
+     */
+    selectNode?: (() => void) | null;
+    /**
+     * When defining a `selectNode` method, you should also provide a
+     * `deselectNode` method to remove the effect again.
+     */
+    deselectNode?: (() => void) | null;
+    /**
+     * This will be called to handle setting the selection inside the
+     * node. The `anchor` and `head` positions are relative to the start
+     * of the node. By default, a DOM selection will be created between
+     * the DOM positions corresponding to those positions, but if you
+     * override it you can do something else.
+     */
+    setSelection?:
+      | ((anchor: number, head: number, root: Document) => void)
+      | null;
+    /**
+     * Can be used to prevent the editor view from trying to handle some
+     * or all DOM events that bubble up from the node view. Events for
+     * which this returns true are not handled by the editor.
+     */
+    stopEvent?: ((event: Event) => boolean) | null;
+    /**
+     * Called when a DOM
+     * [mutation](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+     * or a selection change happens within the view. When the change is
+     * a selection change, the record will have a `type` property of
+     * `"selection"` (which doesn't occur for native mutation records).
+     * Return false if the editor should re-read the selection or
+     * re-parse the range around the mutation, true if it can safely be
+     * ignored.
+     */
+    ignoreMutation?:
+      | ((
+          p:
+            | MutationRecord
+            | {
+                type: "selection";
+                target: Element;
+              }
+        ) => boolean)
+      | null;
+    /**
+     * Called when the node view is removed from the editor or the whole
+     * editor is destroyed.
+     */
+    destroy?: (() => void) | null;
+  }
+}

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -10,33 +10,25 @@ import type { TFields } from "./types/Fields";
 const addEmbedNode = (schemaSpec: OrderedMap<NodeSpec>): OrderedMap<NodeSpec> =>
   schemaSpec.append(baseEmbedSchema);
 
-export type EmbedsSpec<
-  EmbedTypes extends string,
-  EmbedFields extends TFields
-> = { [key in EmbedTypes]: TEmbed<EmbedFields> };
+export type EmbedsSpec<EmbedTypes extends string> = {
+  [key in EmbedTypes]: TEmbed;
+};
 
 // Sometimes we don't need to keep so much type information about the embed
 // spec around when passing it – for example, when consuming it for internal
 // purposes. In this case, using GenericEmbedsSpec avoids the type parameters
 // in EmbedsSpec, improving ergonomics.
-export type GenericEmbedsSpec<FieldAttrs extends TFields> = Record<
-  string,
-  TEmbed<FieldAttrs>
->;
+export type GenericEmbedsSpec = Record<string, TEmbed>;
 
-type GetFieldsFromTEmbed<PEmbed> = PEmbed extends TEmbed<infer Fields>
-  ? Fields
-  : never;
-
-const build = <EmbedKeys extends string, EmbedFields extends TFields>(
-  types: EmbedsSpec<EmbedKeys, EmbedFields>,
+const build = <EmbedKeys extends string>(
+  types: EmbedsSpec<EmbedKeys>,
   predicate = defaultPredicate
 ) => {
   const typeNames = Object.keys(types);
 
   const insertEmbed = <EmbedKey extends EmbedKeys>(
     type: EmbedKey,
-    fields: GetFieldsFromTEmbed<EmbedsSpec<EmbedKey, EmbedFields>[EmbedKey]>
+    fields: TFields
   ) => (
     state: EditorState,
     dispatch: (tr: Transaction<Schema>) => void
@@ -62,7 +54,7 @@ const build = <EmbedKeys extends string, EmbedFields extends TFields>(
     }
   };
 
-  const plugin = createPlugin<EmbedFields>(types, buildCommands(predicate));
+  const plugin = createPlugin(types, buildCommands(predicate));
 
   return {
     insertEmbed,

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -37,7 +37,7 @@ const build = <EmbedKeys extends string>(
       throw new Error(
         `[prosemirror-embeds]: ${type} is not recognised. Only ${typeNames.join(
           ", "
-        )} have can be added`
+        )} can be added`
       );
     }
     const newNode = (state.schema as Schema).nodes[type].createAndFill({

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -2,7 +2,7 @@ import type OrderedMap from "orderedmap";
 import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { baseEmbedSchema } from "./baseSchema";
-import { defaultPredicate } from "./helpers";
+import { buildCommands, defaultPredicate } from "./helpers";
 import { createPlugin } from "./plugin";
 import type { TEmbed } from "./types/Embed";
 import type { TFields } from "./types/Fields";
@@ -55,7 +55,7 @@ const build = <EmbedKeys extends string, EmbedFields extends TFields>(
     );
   };
 
-  const plugin = createPlugin<EmbedFields>(types, predicate);
+  const plugin = createPlugin<EmbedFields>(types, buildCommands(predicate));
 
   return {
     insertEmbed,

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,78 +1,64 @@
 import type OrderedMap from "orderedmap";
-import type { Node, NodeSpec, Schema } from "prosemirror-model";
+import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { buildCommands, defaultPredicate } from "./helpers";
+import { baseEmbedSchema } from "./baseSchema";
+import { defaultPredicate } from "./helpers";
 import { createPlugin } from "./plugin";
 import type { TEmbed } from "./types/Embed";
 import type { TFields } from "./types/Fields";
 
-const addEmbedNode = (schema: OrderedMap<NodeSpec>): OrderedMap<NodeSpec> =>
-  schema.append({
-    embed: {
-      group: "block",
-      attrs: {
-        type: {},
-        fields: {
-          default: {},
-        },
-        hasErrors: {
-          default: false,
-        },
-      },
-      draggable: false,
-      toDOM: (node: Node) => [
-        "embed-attrs",
-        {
-          type: node.attrs.type as string,
-          fields: JSON.stringify(node.attrs.fields),
-          "has-errors": JSON.stringify(node.attrs.hasErrors),
-        },
-      ],
-      parseDOM: [
-        {
-          tag: "embed-attrs",
-          getAttrs: (dom: Element) => {
-            if (typeof dom === "string") {
-              return;
-            }
-            const hasErrorAttr = dom.getAttribute("has-errors");
-            console.log(dom.getAttribute("fields"));
-            return {
-              type: dom.getAttribute("type"),
-              fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
-              hasErrors: hasErrorAttr && hasErrorAttr !== "false",
-            };
-          },
-        },
-      ],
-    },
-  });
+const addEmbedNode = (schemaSpec: OrderedMap<NodeSpec>): OrderedMap<NodeSpec> =>
+  schemaSpec.append(baseEmbedSchema);
 
-const build = (
-  types: Record<string, TEmbed<TFields>>,
+export type EmbedsSpec<
+  EmbedTypes extends string,
+  EmbedFields extends TFields
+> = { [key in EmbedTypes]: TEmbed<EmbedFields> };
+
+// Sometimes we don't need to keep so much type information about the embed
+// spec around when passing it – for example, when consuming it for internal
+// purposes. In this case, using GenericEmbedsSpec avoids the type parameters
+// in EmbedsSpec, improving ergonomics.
+export type GenericEmbedsSpec<FieldAttrs extends TFields> = Record<
+  string,
+  TEmbed<FieldAttrs>
+>;
+
+type GetFieldsFromTEmbed<PEmbed> = PEmbed extends TEmbed<infer Fields>
+  ? Fields
+  : never;
+
+const build = <EmbedKeys extends string, EmbedFields extends TFields>(
+  types: EmbedsSpec<EmbedKeys, EmbedFields>,
   predicate = defaultPredicate
 ) => {
   const typeNames = Object.keys(types);
-  const plugin = createPlugin(types, buildCommands(predicate));
-  return {
-    insertEmbed: (type: string, fields = {}) => (
-      state: EditorState,
-      dispatch: (tr: Transaction<Schema>) => void
-    ): void => {
-      if (!typeNames.includes(type)) {
-        throw new Error(
-          `[prosemirror-embeds]: ${type} is not recognised. Only ${typeNames.join(
-            ", "
-          )} have can be added`
-        );
-      }
-      // check whether we can
-      dispatch(
-        state.tr.replaceSelectionWith(
-          (state.schema as Schema).nodes.embed.create({ type, fields })
-        )
+
+  const insertEmbed = <EmbedKey extends EmbedKeys>(
+    type: EmbedKey,
+    fields: GetFieldsFromTEmbed<EmbedsSpec<EmbedKey, EmbedFields>[EmbedKey]>
+  ) => (
+    state: EditorState,
+    dispatch: (tr: Transaction<Schema>) => void
+  ): void => {
+    if (!typeNames.includes(type)) {
+      throw new Error(
+        `[prosemirror-embeds]: ${type} is not recognised. Only ${typeNames.join(
+          ", "
+        )} have can be added`
       );
-    },
+    }
+    dispatch(
+      state.tr.replaceSelectionWith(
+        (state.schema as Schema).nodes[type].create({ type, fields })
+      )
+    );
+  };
+
+  const plugin = createPlugin<EmbedFields>(types, predicate);
+
+  return {
+    insertEmbed,
     hasErrors: (state: EditorState) => plugin.getState(state).hasErrors,
     plugin,
   };

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -50,7 +50,7 @@ const build = <EmbedKeys extends string>(
       // This shouldn't happen, as the schema should always be able to fill
       // the node with correct children if we're not supplying content –
       // see https://prosemirror.net/docs/ref/#model.NodeType.createAndFill
-      console.warn(`Could not create node for ${type}`);
+      console.warn(`[prosemirror-embeds]: could not create node for ${type}`);
     }
   };
 

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -48,11 +48,18 @@ const build = <EmbedKeys extends string, EmbedFields extends TFields>(
         )} have can be added`
       );
     }
-    dispatch(
-      state.tr.replaceSelectionWith(
-        (state.schema as Schema).nodes[type].create({ type, fields })
-      )
-    );
+    const newNode = (state.schema as Schema).nodes[type].createAndFill({
+      type,
+      fields,
+    });
+    if (newNode) {
+      dispatch(state.tr.replaceSelectionWith(newNode));
+    } else {
+      // This shouldn't happen, as the schema should always be able to fill
+      // the node with correct children if we're not supplying content –
+      // see https://prosemirror.net/docs/ref/#model.NodeType.createAndFill
+      console.warn(`Could not create node for ${type}`);
+    }
   };
 
   const plugin = createPlugin<EmbedFields>(types, buildCommands(predicate));

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import type { TFields } from "../../types/Fields";
+import { NestedEditorView } from "../../mounters/react/NestedEditorView";
+import type { NestedEditorMap } from "../../types/Embed";
+import type { TImageFields } from "./types/Fields";
 
 type Props = {
-  fields: {
-    caption: string;
-    src: string;
-    alt: string;
-  };
+  fields: TImageFields;
   errors: Record<string, string[]>;
-  updateFields: (fields: TFields) => void;
+  updateFields: (fields: Partial<TImageFields>) => void;
+  // @todo Make this schema specific to the embed once created
+  nestedEditors: NestedEditorMap;
   editSrc: boolean;
 };
 
@@ -17,9 +17,14 @@ export const ImageEmbed: React.FunctionComponent<Props> = ({
   errors,
   updateFields,
   editSrc,
+  nestedEditors,
 }) => (
   <div>
     <img style={{ width: "250px", height: "auto" }} src={src} alt={alt} />
+    {Object.entries(nestedEditors).map(([nameType, editor]) => (
+      <NestedEditorView key={nameType} name={nameType} editor={editor} />
+    ))}
+
     <div>
       <label>
         Caption

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -9,7 +9,6 @@ type Props = {
   updateFields: (fields: TFields) => void;
   // @todo Make this schema specific to the embed once created
   nestedEditors: NestedEditorMap;
-  editSrc: boolean;
 };
 
 export const ImageEmbedTestId = "ImageEmbed";

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -12,14 +12,13 @@ type Props = {
   editSrc: boolean;
 };
 
+export const ImageEmbedTestId = "ImageEmbed";
+
 export const ImageEmbed: React.FunctionComponent<Props> = ({
-  fields: { caption, src, alt },
-  errors,
-  updateFields,
-  editSrc,
+  fields: { src, alt },
   nestedEditors,
 }) => (
-  <div>
+  <div data-cy={ImageEmbedTestId}>
     <img style={{ width: "250px", height: "auto" }} src={src} alt={alt} />
     {Object.entries(nestedEditors).map(([nameType, editor]) => (
       <NestedEditorView key={nameType} name={nameType} editor={editor} />

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { NestedEditorView } from "../../mounters/react/NestedEditorView";
 import type { NestedEditorMap } from "../../types/Embed";
-import type { TImageFields } from "./types/Fields";
+import type { TFields } from "../../types/Fields";
 
 type Props = {
-  fields: TImageFields;
+  fields: TFields;
   errors: Record<string, string[]>;
-  updateFields: (fields: Partial<TImageFields>) => void;
+  updateFields: (fields: TFields) => void;
   // @todo Make this schema specific to the embed once created
   nestedEditors: NestedEditorMap;
   editSrc: boolean;

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -24,44 +24,5 @@ export const ImageEmbed: React.FunctionComponent<Props> = ({
     {Object.entries(nestedEditors).map(([nameType, editor]) => (
       <NestedEditorView key={nameType} name={nameType} editor={editor} />
     ))}
-
-    <div>
-      <label>
-        Caption
-        <input
-          type="text"
-          value={caption}
-          onInput={(e) =>
-            e.target instanceof HTMLInputElement &&
-            updateFields({ caption: e.target.value })
-          }
-        />
-      </label>
-      <label>
-        Alt
-        <input
-          type="text"
-          value={alt}
-          style={{ borderColor: errors.alt.length ? "red" : undefined }}
-          onInput={(e) =>
-            e.target instanceof HTMLInputElement &&
-            updateFields({ alt: e.target.value })
-          }
-        />
-      </label>
-      {editSrc && (
-        <label>
-          Src
-          <input
-            type="text"
-            value={src}
-            onInput={(e) =>
-              e.target instanceof HTMLInputElement &&
-              updateFields({ src: e.target.value })
-            }
-          />
-        </label>
-      )}
-    </div>
   </div>
 );

--- a/src/embeds/image/embed.tsx
+++ b/src/embeds/image/embed.tsx
@@ -1,21 +1,62 @@
+import type { NodeSpec } from "prosemirror-model";
 import React from "react";
-import { reactMount } from "../../mounters/react/mount";
+import { createReactRenderer } from "../../mounters/react/mount";
 import type { TEmbed } from "../../types/Embed";
 import { ImageEmbed } from "./ImageEmbed";
 import type { TImageFields } from "./types/Fields";
 
+export const imageSchemaSpec: NodeSpec = {
+  caption: {
+    group: "block",
+    content: "paragraph",
+    toDOM() {
+      return ["div", { class: "imageNative-caption" }, 0];
+    },
+    parseDOM: [{ tag: "div" }],
+  },
+  altText: {
+    group: "block",
+    content: "paragraph",
+    toDOM() {
+      return ["div", { class: "imageNative-altText" }, 0];
+    },
+    parseDOM: [{ tag: "div" }],
+  },
+  imageEmbed: {
+    group: "caption altText",
+    attrs: {
+      type: {},
+      fields: {
+        default: {},
+      },
+      hasErrors: {
+        default: false,
+      },
+    },
+  },
+};
+
+const defaultImageFields: TImageFields = {
+  caption: "",
+  src: "",
+  alt: "",
+};
+
 export const createImageEmbed = ({
   editSrc = false,
 } = {}): TEmbed<TImageFields> =>
-  reactMount<TImageFields>(
-    (fields, errors, updateFields) => (
-      <ImageEmbed
-        fields={fields}
-        errors={errors}
-        updateFields={updateFields}
-        editSrc={editSrc}
-      />
-    ),
+  createReactRenderer<TImageFields>(defaultImageFields)(
+    (fields, errors, updateFields, nestedEditors) => {
+      return (
+        <ImageEmbed
+          fields={fields}
+          errors={errors}
+          updateFields={updateFields}
+          editSrc={editSrc}
+          nestedEditors={nestedEditors}
+        />
+      );
+    },
     ({ alt }) => (alt ? null : { alt: ["Alt tag must be set"] }),
     { caption: "", src: "", alt: "" }
   );

--- a/src/embeds/image/embed.tsx
+++ b/src/embeds/image/embed.tsx
@@ -1,9 +1,8 @@
 import type { NodeSpec } from "prosemirror-model";
 import React from "react";
-import { createReactRenderer } from "../../mounters/react/mount";
+import { createReactEmbed } from "../../mounters/react/mount";
 import type { TEmbed } from "../../types/Embed";
 import { ImageEmbed } from "./ImageEmbed";
-import type { TImageFields } from "./types/Fields";
 
 export const imageSchemaSpec: NodeSpec = {
   caption: {
@@ -36,16 +35,8 @@ export const imageSchemaSpec: NodeSpec = {
   },
 };
 
-const defaultImageFields: TImageFields = {
-  caption: "",
-  src: "",
-  alt: "",
-};
-
-export const createImageEmbed = ({
-  editSrc = false,
-} = {}): TEmbed<TImageFields> =>
-  createReactRenderer<TImageFields>(defaultImageFields)(
+export const createImageEmbed = ({ editSrc = false } = {}): TEmbed =>
+  createReactEmbed(
     (fields, errors, updateFields, nestedEditors) => {
       return (
         <ImageEmbed

--- a/src/embeds/image/embed.tsx
+++ b/src/embeds/image/embed.tsx
@@ -35,7 +35,7 @@ export const imageSchemaSpec: NodeSpec = {
   },
 };
 
-export const createImageEmbed = ({ editSrc = false } = {}): TEmbed =>
+export const createImageEmbed = (): TEmbed =>
   createReactEmbed(
     (fields, errors, updateFields, nestedEditors) => {
       return (
@@ -43,7 +43,6 @@ export const createImageEmbed = ({ editSrc = false } = {}): TEmbed =>
           fields={fields}
           errors={errors}
           updateFields={updateFields}
-          editSrc={editSrc}
           nestedEditors={nestedEditors}
         />
       );

--- a/src/embeds/image/types/Fields.ts
+++ b/src/embeds/image/types/Fields.ts
@@ -1,5 +1,0 @@
-export type TImageFields = {
-  caption: string;
-  src: string;
-  alt: string;
-};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,7 +26,7 @@ const nodesBetween = (state: EditorState, _from: number, _to: number) => {
   return arr;
 };
 
-type TPredicate = (
+export type TPredicate = (
   node: Node,
   pos: number,
   parent: Node,
@@ -120,37 +120,38 @@ const moveNode = (consumerPredicate: TPredicate) => (
   return true;
 };
 
-const moveNodeUp = (predicate: TPredicate) => (pos: number) => (
+const moveNodeUp = (predicate: TPredicate, pos: number) => (
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false
 ) => moveNode(predicate)(pos, state, dispatch, "up");
 
-const moveNodeDown = (predicate: TPredicate) => (pos: number) => (
+const moveNodeDown = (predicate: TPredicate, pos: number) => (
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false
 ) => moveNode(predicate)(pos, state, dispatch, "down");
 
-const moveNodeTop = (predicate: TPredicate) => (pos: number) => (
+const moveNodeTop = (predicate: TPredicate, pos: number) => (
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false
 ) => moveNode(predicate)(pos, state, dispatch, "top");
 
-const moveNodeBottom = (predicate: TPredicate) => (pos: number) => (
+const moveNodeBottom = (predicate: TPredicate, pos: number) => (
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false
 ) => moveNode(predicate)(pos, state, dispatch, "bottom");
 
-const buildMoveCommands = (predicate: TPredicate) => (
+const buildMoveCommands = (
+  predicate: TPredicate,
   pos: number,
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false
 ) => ({
-  moveUp: (run = true) => moveNodeUp(predicate)(pos)(state, run && dispatch),
+  moveUp: (run = true) => moveNodeUp(predicate, pos)(state, run && dispatch),
   moveDown: (run = true) =>
-    moveNodeDown(predicate)(pos)(state, run && dispatch),
-  moveTop: (run = true) => moveNodeTop(predicate)(pos)(state, run && dispatch),
+    moveNodeDown(predicate, pos)(state, run && dispatch),
+  moveTop: (run = true) => moveNodeTop(predicate, pos)(state, run && dispatch),
   moveBottom: (run = true) =>
-    moveNodeBottom(predicate)(pos)(state, run && dispatch),
+    moveNodeBottom(predicate, pos)(state, run && dispatch),
 });
 
 const removeNode = (pos: number) => (
@@ -158,12 +159,13 @@ const removeNode = (pos: number) => (
   dispatch: ((tr: Transaction) => void) | false
 ) => (dispatch ? dispatch(state.tr.deleteRange(pos, pos + 1)) : true);
 
-const buildCommands = (predicate: TPredicate) => (
+const buildCommands = (
+  predicate: TPredicate,
   pos: number,
   state: EditorState,
   dispatch: (tr: Transaction) => void
 ): TCommands => ({
-  ...buildMoveCommands(predicate)(pos, state, dispatch),
+  ...buildMoveCommands(predicate, pos, state, dispatch),
   remove: (run = true) => removeNode(pos)(state, run && dispatch),
 });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -190,7 +190,7 @@ const createDecorations = (name: string) => (state: EditorState) => {
     if (node.type.name === name) {
       decorations.push(
         Decoration.node(
-          pos + 1,
+          pos,
           pos + node.nodeSize,
           {},
           {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,10 +2,11 @@ import type { Node } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { AllSelection } from "prosemirror-state";
 // import { canJoin } from 'prosemirror-transform';
+import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import type { TCommands } from "./types/Commands";
 
 type TNodesBetweenArgs = [Node, number, Node, number];
+export type Commands = ReturnType<typeof buildCommands>;
 
 const nodesBetween = (state: EditorState, _from: number, _to: number) => {
   const dir = _to - _from;
@@ -26,7 +27,7 @@ const nodesBetween = (state: EditorState, _from: number, _to: number) => {
   return arr;
 };
 
-export type TPredicate = (
+type TPredicate = (
   node: Node,
   pos: number,
   parent: Node,
@@ -59,7 +60,8 @@ const nextPosFinder = (consumerPredicate: TPredicate) => (
 ): number | null => {
   const all = new AllSelection(state.doc);
   const predicate = findPredicate(consumerPredicate, pos);
-
+  const node = state.doc.nodeAt(pos);
+  const nodeSize = node ? node.nodeSize : pos;
   switch (dir) {
     case "up": {
       const [, nextNodePos = null] =
@@ -78,17 +80,22 @@ const nextPosFinder = (consumerPredicate: TPredicate) => (
     }
     case "bottom": {
       // as this is a node view the end is just pos + 1
-      return pos + 1 === all.to ? null : all.to;
+      return pos + nodeSize === all.to ? null : all.to;
     }
   }
 };
 
 const moveNode = (consumerPredicate: TPredicate) => (
-  pos: number,
+  getPos: () => number | undefined,
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false,
   dir: TDirection
 ) => {
+  const pos = getPos();
+  if (pos === undefined) {
+    return false;
+  }
+
   const nextPos = nextPosFinder(consumerPredicate)(pos, state, dir);
 
   if (nextPos === null) {
@@ -100,12 +107,12 @@ const moveNode = (consumerPredicate: TPredicate) => (
   }
 
   const { node } = state.doc.childAfter(pos);
-
-  const tr = state.tr.deleteRange(pos, pos + 1);
+  const to = node ? pos + node.nodeSize : pos;
+  const tr = state.tr.deleteRange(pos, to);
 
   if (node && (nextPos || nextPos === 0)) {
     const insertPos = tr.mapping.mapResult(nextPos).pos;
-    tr.insert(insertPos, node.type.create({ ...node.attrs }));
+    tr.insert(insertPos, node.cut(0));
   }
 
   // const mappedPos = tr.mapping.mapResult(pos).pos;
@@ -120,67 +127,71 @@ const moveNode = (consumerPredicate: TPredicate) => (
   return true;
 };
 
-const moveNodeUp = (predicate: TPredicate, pos: number) => (
-  state: EditorState,
-  dispatch: ((tr: Transaction) => void) | false
-) => moveNode(predicate)(pos, state, dispatch, "up");
+const moveNodeUp = (predicate: TPredicate) => (
+  getPos: () => number | undefined
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "up");
 
-const moveNodeDown = (predicate: TPredicate, pos: number) => (
-  state: EditorState,
-  dispatch: ((tr: Transaction) => void) | false
-) => moveNode(predicate)(pos, state, dispatch, "down");
+const moveNodeDown = (predicate: TPredicate) => (
+  getPos: () => number | undefined
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "down");
 
-const moveNodeTop = (predicate: TPredicate, pos: number) => (
-  state: EditorState,
-  dispatch: ((tr: Transaction) => void) | false
-) => moveNode(predicate)(pos, state, dispatch, "top");
+const moveNodeTop = (predicate: TPredicate) => (
+  getPos: () => number | undefined
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "top");
 
-const moveNodeBottom = (predicate: TPredicate, pos: number) => (
-  state: EditorState,
-  dispatch: ((tr: Transaction) => void) | false
-) => moveNode(predicate)(pos, state, dispatch, "bottom");
+const moveNodeBottom = (predicate: TPredicate) => (
+  getPos: () => number | undefined
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "bottom");
 
-const buildMoveCommands = (
-  predicate: TPredicate,
-  pos: number,
-  state: EditorState,
-  dispatch: ((tr: Transaction) => void) | false
+const buildMoveCommands = (predicate: TPredicate) => (
+  getPos: () => number | undefined,
+  view: EditorView
 ) => ({
-  moveUp: (run = true) => moveNodeUp(predicate, pos)(state, run && dispatch),
-  moveDown: (run = true) =>
-    moveNodeDown(predicate, pos)(state, run && dispatch),
-  moveTop: (run = true) => moveNodeTop(predicate, pos)(state, run && dispatch),
-  moveBottom: (run = true) =>
-    moveNodeBottom(predicate, pos)(state, run && dispatch),
+  moveUp: (run = true) => moveNodeUp(predicate)(getPos)(view, run),
+  moveDown: (run = true) => moveNodeDown(predicate)(getPos)(view, run),
+  moveTop: (run = true) => moveNodeTop(predicate)(getPos)(view, run),
+  moveBottom: (run = true) => moveNodeBottom(predicate)(getPos)(view, run),
 });
 
-const removeNode = (pos: number) => (
+const removeNode = (getPos: () => number | undefined) => (
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false
-) => (dispatch ? dispatch(state.tr.deleteRange(pos, pos + 1)) : true);
+) => {
+  if (!dispatch) {
+    return true;
+  }
+  const pos = getPos();
+  if (pos === undefined) {
+    return;
+  }
+  const { node } = state.doc.childAfter(pos);
+  const to = node ? pos + node.nodeSize : pos;
 
-const buildCommands = (
-  predicate: TPredicate,
-  pos: number,
-  state: EditorState,
-  dispatch: (tr: Transaction) => void
-): TCommands => ({
-  ...buildMoveCommands(predicate, pos, state, dispatch),
-  remove: (run = true) => removeNode(pos)(state, run && dispatch),
+  dispatch(state.tr.deleteRange(pos, to));
+};
+
+const buildCommands = (predicate: TPredicate) => (
+  getPos: () => number | undefined,
+  view: EditorView
+) => ({
+  ...buildMoveCommands(predicate)(getPos, view),
+  remove: (run = true) => removeNode(getPos)(view.state, run && view.dispatch),
 });
 
 // this forces our view to update every time an edit is made by inserting
 // a decoration right on top of it and updating it's attributes
-const createDecorations = (name: string) => (
-  state: EditorState
-): DecorationSet => {
+const createDecorations = (name: string) => (state: EditorState) => {
   const decorations: Decoration[] = [];
   state.doc.descendants((node, pos) => {
     if (node.type.name === name) {
       decorations.push(
         Decoration.node(
-          pos,
           pos + 1,
+          pos + node.nodeSize,
           {},
           {
             key: Math.random().toString(),
@@ -191,6 +202,7 @@ const createDecorations = (name: string) => (
       );
     }
   });
+
   return DecorationSet.create(state.doc, decorations);
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -79,7 +79,6 @@ const nextPosFinder = (consumerPredicate: TPredicate) => (
       return pos === all.from ? null : all.from;
     }
     case "bottom": {
-      // as this is a node view the end is just pos + 1
       return pos + nodeSize === all.to ? null : all.to;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,6 @@ document.body.appendChild(embedButton);
 
 // Handy debugging tools
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- debug
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any -- debug
 (window as any).ProseMirrorDevTools.applyDevTools(view, { EditorState });
 ((window as unknown) as { view: EditorView }).view = view;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const get = () => {
 const set = (doc: Node) => window.localStorage.setItem("pm", docToHtml(doc));
 
 const { plugin: embedPlugin, insertEmbed, hasErrors } = build({
-  imageEmbed: createImageEmbed({ editSrc: true }),
+  imageEmbed: createImageEmbed(),
 });
 
 const editorElement = document.querySelector("#editor");

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Node } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
+import { addTestDecorationPlugin } from "../cypress/helpers/editor";
 import { build } from "./embed";
 import { createImageEmbed } from "./embeds/image/embed";
 import { docToHtml, htmlToDoc, mySchema } from "./prosemirrorSetup";
@@ -34,7 +35,11 @@ const highlightErrors = (state: EditorState) => {
 const view = new EditorView(editorElement, {
   state: EditorState.create({
     doc: get(),
-    plugins: [...exampleSetup({ schema: mySchema }), embedPlugin],
+    plugins: [
+      ...exampleSetup({ schema: mySchema }),
+      embedPlugin,
+      addTestDecorationPlugin,
+    ],
   }),
   dispatchTransaction: (tr: Transaction) => {
     const state = view.state.apply(tr);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,17 @@
-import type OrderedMap from "orderedmap";
 import { exampleSetup } from "prosemirror-example-setup";
-import type { Node, NodeSpec } from "prosemirror-model";
-import { DOMParser, DOMSerializer, Schema } from "prosemirror-model";
-import { schema } from "prosemirror-schema-basic";
-import type { Plugin, Transaction } from "prosemirror-state";
+import type { Node } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { addEmbedNode, build } from "./embed";
+import { build } from "./embed";
 import { createImageEmbed } from "./embeds/image/embed";
-
-// Mix the nodes from prosemirror-schema-list into the basic schema to
-// create a schema with list support.
-const mySchema = new Schema({
-  nodes: addEmbedNode(schema.spec.nodes as OrderedMap<NodeSpec>),
-  marks: schema.spec.marks,
-});
-
-const parser = DOMParser.fromSchema(mySchema);
-const serializer = DOMSerializer.fromSchema(mySchema);
-
-const docToHtml = (doc: Node) => {
-  const dom = serializer.serializeFragment(doc.content);
-  const e = document.createElement("div");
-  e.appendChild(dom);
-  return e.innerHTML;
-};
-
-const htmlToDoc = (html: string) => {
-  const dom = document.createElement("div");
-  dom.innerHTML = html;
-  return parser.parse(dom);
-};
+import { docToHtml, htmlToDoc, mySchema } from "./prosemirrorSetup";
 
 const get = () => {
   const state = window.localStorage.getItem("pm");
-  return state ? htmlToDoc(state) : mySchema.nodes.doc.createAndFill();
+  return state
+    ? htmlToDoc(state)
+    : htmlToDoc(document.getElementById("content")?.innerHTML ?? "");
 };
 const set = (doc: Node) => window.localStorage.setItem("pm", docToHtml(doc));
 
@@ -71,6 +48,7 @@ highlightErrors(view.state);
 
 const embedButton = document.createElement("button");
 embedButton.innerHTML = "Embed";
+embedButton.id = "embed";
 embedButton.addEventListener("click", () =>
   insertEmbed("imageEmbed", { alt: "", caption: "", src: "" })(
     view.state,
@@ -83,3 +61,4 @@ document.body.appendChild(embedButton);
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- debug
 (window as any).ProseMirrorDevTools.applyDevTools(view, { EditorState });
+((window as unknown) as { view: EditorView }).view = view;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,8 @@ const get = () => {
 const set = (doc: Node) => window.localStorage.setItem("pm", docToHtml(doc));
 
 const { plugin: embedPlugin, insertEmbed, hasErrors } = build({
-  image: createImageEmbed({ editSrc: true }),
+  imageEmbed: createImageEmbed({ editSrc: true }),
 });
-
-// window.localStorage.setItem('pm', ''); // reset state for debugging
 
 const editorElement = document.querySelector("#editor");
 
@@ -71,12 +69,13 @@ const view = new EditorView(editorElement, {
 
 highlightErrors(view.state);
 
-const insertImageEmbed = insertEmbed("image");
-
 const embedButton = document.createElement("button");
 embedButton.innerHTML = "Embed";
 embedButton.addEventListener("click", () =>
-  insertImageEmbed(view.state, view.dispatch)
+  insertEmbed("imageEmbed", { alt: "", caption: "", src: "" })(
+    view.state,
+    view.dispatch
+  )
 );
 document.body.appendChild(embedButton);
 

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -4,18 +4,18 @@ import type { NestedEditorMap, TEmbed } from "./types/Embed";
 import type { TFields } from "./types/Fields";
 import type { TValidator } from "./types/Validator";
 
-type Subscriber<FieldAttrs extends TFields> = (
-  fields: FieldAttrs,
+type Subscriber = (
+  fields: TFields,
   commands: ReturnType<TCommandCreator>
 ) => void;
 
-type Updater<FieldAttrs extends TFields> = {
-  update: Subscriber<FieldAttrs>;
-  subscribe: (s: Subscriber<FieldAttrs>) => void;
+type Updater = {
+  update: Subscriber;
+  subscribe: (s: Subscriber) => void;
 };
 
-const createUpdater = <FieldAttrs extends TFields>(): Updater<FieldAttrs> => {
-  let sub: Subscriber<FieldAttrs> = () => undefined;
+const createUpdater = (): Updater => {
+  let sub: Subscriber = () => undefined;
   return {
     subscribe: (fn) => {
       sub = fn;
@@ -24,36 +24,28 @@ const createUpdater = <FieldAttrs extends TFields>(): Updater<FieldAttrs> => {
   };
 };
 
-type TRenderer<T, FieldAttrs extends TFields> = (
-  consumer: TConsumer<T, FieldAttrs>,
-  validate: TValidator<FieldAttrs>,
+type TRenderer<T> = (
+  consumer: TConsumer<T>,
+  validate: TValidator,
   // The HTMLElement representing the node parent. The renderer can mount onto this node.
   dom: HTMLElement,
   // The HTMLElement representing the node's children, if there are any. The renderer can
   // choose to append this node if it needs to render children.
   nestedEditors: NestedEditorMap,
-  updateState: (fields: Partial<FieldAttrs>) => void,
-  fields: FieldAttrs,
+  updateState: (fields: TFields) => void,
+  fields: TFields,
   commands: TCommands,
   subscribe: (
-    fn: (fields: FieldAttrs, commands: ReturnType<TCommandCreator>) => void
+    fn: (fields: TFields, commands: ReturnType<TCommandCreator>) => void
   ) => void
 ) => void;
 
-export const mount = <FieldAttrs extends TFields, RenderReturn>(
-  render: TRenderer<RenderReturn, FieldAttrs>
-) => (
-  consumer: TConsumer<RenderReturn, FieldAttrs>,
-  validate: TValidator<FieldAttrs>,
-  defaultState: FieldAttrs
-): TEmbed<FieldAttrs> => (
-  dom,
-  nestedEditors,
-  updateState,
-  fields,
-  commands
-) => {
-  const updater = createUpdater<FieldAttrs>();
+export const mount = <RenderReturn>(render: TRenderer<RenderReturn>) => (
+  consumer: TConsumer<RenderReturn>,
+  validate: TValidator,
+  defaultState: TFields
+): TEmbed => (dom, nestedEditors, updateState, fields, commands) => {
+  const updater = createUpdater();
   render(
     consumer,
     validate,

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,49 +1,64 @@
 import type { TCommandCreator, TCommands } from "./types/Commands";
 import type { TConsumer } from "./types/Consumer";
-import type { TEmbed } from "./types/Embed";
+import type { NestedEditorMap, TEmbed } from "./types/Embed";
 import type { TFields } from "./types/Fields";
 import type { TValidator } from "./types/Validator";
 
-const createUpdater = () => {
-  let sub: Subscriber = () => undefined;
-  return {
-    subscribe: (fn: Subscriber) => {
-      sub = fn;
-    },
-    update: ((fields, commands) => sub(fields, commands)) as Subscriber,
-  };
-};
-
-type Subscriber = (
-  fields: TFields,
+type Subscriber<FieldAttrs extends TFields> = (
+  fields: FieldAttrs,
   commands: ReturnType<TCommandCreator>
 ) => void;
 
-// @placeholder
-type TRenderer<T> = (
-  consumer: TConsumer<T, TFields>,
-  validate: TValidator<TFields>,
+type Updater<FieldAttrs extends TFields> = {
+  update: Subscriber<FieldAttrs>;
+  subscribe: (s: Subscriber<FieldAttrs>) => void;
+};
+
+const createUpdater = <FieldAttrs extends TFields>(): Updater<FieldAttrs> => {
+  let sub: Subscriber<FieldAttrs> = () => undefined;
+  return {
+    subscribe: (fn) => {
+      sub = fn;
+    },
+    update: (fields, commands) => sub(fields, commands),
+  };
+};
+
+type TRenderer<T, FieldAttrs extends TFields> = (
+  consumer: TConsumer<T, FieldAttrs>,
+  validate: TValidator<FieldAttrs>,
+  // The HTMLElement representing the node parent. The renderer can mount onto this node.
   dom: HTMLElement,
-  updateState: (fields: TFields) => void,
-  fields: TFields,
+  // The HTMLElement representing the node's children, if there are any. The renderer can
+  // choose to append this node if it needs to render children.
+  nestedEditors: NestedEditorMap,
+  updateState: (fields: Partial<FieldAttrs>) => void,
+  fields: FieldAttrs,
   commands: TCommands,
   subscribe: (
-    fn: (fields: TFields, commands: ReturnType<TCommandCreator>) => void
+    fn: (fields: FieldAttrs, commands: ReturnType<TCommandCreator>) => void
   ) => void
 ) => void;
 
-export const mount = <RenderReturn>(render: TRenderer<RenderReturn>) => <
-  FieldAttrs extends TFields
->(
+export const mount = <FieldAttrs extends TFields, RenderReturn>(
+  render: TRenderer<RenderReturn, FieldAttrs>
+) => (
   consumer: TConsumer<RenderReturn, FieldAttrs>,
-  validate: TValidator<TFields>,
+  validate: TValidator<FieldAttrs>,
   defaultState: FieldAttrs
-): TEmbed<FieldAttrs> => (dom, updateState, fields, commands) => {
-  const updater = createUpdater();
+): TEmbed<FieldAttrs> => (
+  dom,
+  nestedEditors,
+  updateState,
+  fields,
+  commands
+) => {
+  const updater = createUpdater<FieldAttrs>();
   render(
     consumer,
     validate,
     dom,
+    nestedEditors,
     (fields) => updateState(fields, !!validate(fields)),
     Object.assign({}, defaultState, fields),
     commands,

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -1,4 +1,3 @@
-import type { Schema } from "prosemirror-model";
 import type { ReactElement } from "react";
 import React, { Component } from "react";
 import type { TCommands } from "../../types/Commands";

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -65,7 +65,6 @@ export class EmbedProvider<FieldAttrs extends TFields> extends Component<
   }
 
   onStateChange(): void {
-    console.log("onStateChange", this.state.fields);
     this.props.onStateChange(this.state.fields);
   }
 

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -17,27 +17,23 @@ const fieldErrors = (fields: TFields, errors: TErrors | null) =>
     {}
   );
 
-type IProps<FieldAttrs extends TFields> = {
-  subscribe: (fn: (fields: FieldAttrs, commands: TCommands) => void) => void;
+type IProps = {
+  subscribe: (fn: (fields: TFields, commands: TCommands) => void) => void;
   commands: TCommands;
-  fields: FieldAttrs;
-  defaultFields: FieldAttrs;
-  onStateChange: (fields: Partial<FieldAttrs>) => void;
-  validate: TValidator<FieldAttrs>;
-  consumer: TConsumer<ReactElement, FieldAttrs>;
+  fields: TFields;
+  onStateChange: (fields: TFields) => void;
+  validate: TValidator;
+  consumer: TConsumer<ReactElement>;
   nestedEditors: NestedEditorMap;
 };
 
-type IState<FieldAttrs extends TFields> = {
+type IState = {
   commands: TCommands;
-  fields: FieldAttrs;
+  fields: TFields;
 };
 
-export class EmbedProvider<FieldAttrs extends TFields> extends Component<
-  IProps<FieldAttrs>,
-  IState<FieldAttrs>
-> {
-  constructor(props: IProps<FieldAttrs>) {
+export class EmbedProvider extends Component<IProps, IState> {
+  constructor(props: IProps) {
     super(props);
 
     this.updateFields = this.updateFields.bind(this);
@@ -49,7 +45,7 @@ export class EmbedProvider<FieldAttrs extends TFields> extends Component<
   }
 
   componentDidMount() {
-    this.props.subscribe((fields = this.props.defaultFields, commands) =>
+    this.props.subscribe((fields, commands) =>
       this.updateState(
         {
           commands,
@@ -67,10 +63,7 @@ export class EmbedProvider<FieldAttrs extends TFields> extends Component<
     this.props.onStateChange(this.state.fields);
   }
 
-  updateState(
-    state: Partial<IState<FieldAttrs>>,
-    notifyListeners: boolean
-  ): void {
+  updateState(state: Partial<IState>, notifyListeners: boolean): void {
     this.setState(
       { ...this.state, ...state },
       () => notifyListeners && this.onStateChange()

--- a/src/mounters/react/EmbedWrapper.tsx
+++ b/src/mounters/react/EmbedWrapper.tsx
@@ -68,6 +68,13 @@ type Props = {
   children?: ReactElement;
 } & ReturnType<TCommandCreator>;
 
+export const embedWrapperTestId = "EmbedWrapper";
+export const moveTopTestId = "EmbedWrapper__moveTop";
+export const moveBottomTestId = "EmbedWrapper__moveBottom";
+export const moveUpTestId = "EmbedWrapper__moveUp";
+export const moveDownTestId = "EmbedWrapper__moveDown";
+export const removeTestId = "EmbedWrapper__remove";
+
 export const EmbedWrapper: React.FunctionComponent<Props> = ({
   name,
   moveUp,
@@ -77,31 +84,49 @@ export const EmbedWrapper: React.FunctionComponent<Props> = ({
   remove,
   children,
 }) => (
-  <Container>
+  <Container data-cy={embedWrapperTestId}>
     <Header>
       <Title>{name}</Title>
     </Header>
     <Body>
       <Panel>{children}</Panel>
       <Actions>
-        <Button disabled={!moveTop(false)} onClick={() => moveTop(true)}>
+        <Button
+          data-cy={moveTopTestId}
+          disabled={!moveTop(false)}
+          onClick={() => moveTop(true)}
+        >
           ↟
         </Button>
-        <Button expanded disabled={!moveUp(false)} onClick={() => moveUp(true)}>
+        <Button
+          data-cy={moveUpTestId}
+          expanded
+          disabled={!moveUp(false)}
+          onClick={() => moveUp(true)}
+        >
           ↑
         </Button>
         <Button
+          data-cy={moveDownTestId}
           expanded
           disabled={!moveDown(false)}
           onClick={() => moveDown(true)}
         >
           ↓
         </Button>
-        <Button disabled={!moveBottom(false)} onClick={() => moveBottom(true)}>
+        <Button
+          data-cy={moveBottomTestId}
+          disabled={!moveBottom(false)}
+          onClick={() => moveBottom(true)}
+        >
           ↡
         </Button>
 
-        <Button disabled={!remove(false)} onClick={() => remove(true)}>
+        <Button
+          data-cy={removeTestId}
+          disabled={!remove(false)}
+          onClick={() => remove(true)}
+        >
           ✕
         </Button>
       </Actions>

--- a/src/mounters/react/NestedEditorView.tsx
+++ b/src/mounters/react/NestedEditorView.tsx
@@ -18,7 +18,7 @@ export const NestedEditorView: React.FunctionComponent<Props> = ({
     if (!editorRef.current) {
       return;
     }
-    editorRef.current.appendChild(editor.dom);
+    editorRef.current.appendChild(editor.nodeViewElement);
   }, []);
   return (
     <div data-cy={getNestedViewTestId(name)}>

--- a/src/mounters/react/NestedEditorView.tsx
+++ b/src/mounters/react/NestedEditorView.tsx
@@ -7,6 +7,8 @@ type Props = {
   editor: RTENodeView<Schema>;
 };
 
+export const getNestedViewTestId = (name: string) => `NestedEditorView-${name}`;
+
 export const NestedEditorView: React.FunctionComponent<Props> = ({
   name,
   editor,
@@ -19,7 +21,7 @@ export const NestedEditorView: React.FunctionComponent<Props> = ({
     editorRef.current.appendChild(editor.dom);
   }, []);
   return (
-    <div>
+    <div data-cy={getNestedViewTestId(name)}>
       <label>
         <strong>{name}</strong>
       </label>

--- a/src/mounters/react/NestedEditorView.tsx
+++ b/src/mounters/react/NestedEditorView.tsx
@@ -1,0 +1,29 @@
+import type { Schema } from "prosemirror-model";
+import React, { useEffect, useRef } from "react";
+import type { RTENodeView } from "../../nodeViews/RTENode";
+
+type Props = {
+  name: string;
+  editor: RTENodeView<Schema>;
+};
+
+export const NestedEditorView: React.FunctionComponent<Props> = ({
+  name,
+  editor,
+}) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!editorRef.current) {
+      return;
+    }
+    editorRef.current.appendChild(editor.dom);
+  }, []);
+  return (
+    <div>
+      <label>
+        <strong>{name}</strong>
+      </label>
+      <div className="NestedEditorView" ref={editorRef}></div>
+    </div>
+  );
+};

--- a/src/mounters/react/mount.tsx
+++ b/src/mounters/react/mount.tsx
@@ -2,34 +2,29 @@ import type { ReactElement } from "react";
 import React from "react";
 import { render } from "react-dom";
 import { mount } from "../../mount";
-import type { TFields } from "../../types/Fields";
 import { EmbedProvider } from "./EmbedProvider";
 
-export const createReactRenderer = <FieldAttrs extends TFields>(
-  defaultFields: FieldAttrs
-) =>
-  mount<FieldAttrs, ReactElement>(
-    (
-      consumer,
-      validate,
-      dom,
-      nestedEditors,
-      updateState,
-      fields,
-      commands,
-      subscribe
-    ) =>
-      render(
-        <EmbedProvider
-          subscribe={subscribe}
-          onStateChange={updateState}
-          defaultFields={defaultFields}
-          fields={fields}
-          validate={validate}
-          commands={commands}
-          consumer={consumer}
-          nestedEditors={nestedEditors}
-        />,
-        dom
-      )
-  );
+export const createReactEmbed = mount<ReactElement>(
+  (
+    consumer,
+    validate,
+    dom,
+    nestedEditors,
+    updateState,
+    fields,
+    commands,
+    subscribe
+  ) =>
+    render(
+      <EmbedProvider
+        subscribe={subscribe}
+        onStateChange={updateState}
+        fields={fields}
+        validate={validate}
+        commands={commands}
+        consumer={consumer}
+        nestedEditors={nestedEditors}
+      />,
+      dom
+    )
+);

--- a/src/mounters/react/mount.tsx
+++ b/src/mounters/react/mount.tsx
@@ -2,19 +2,34 @@ import type { ReactElement } from "react";
 import React from "react";
 import { render } from "react-dom";
 import { mount } from "../../mount";
+import type { TFields } from "../../types/Fields";
 import { EmbedProvider } from "./EmbedProvider";
 
-export const reactMount = mount<ReactElement>(
-  (consumer, validate, dom, updateState, fields, commands, subscribe) =>
-    render(
-      <EmbedProvider
-        subscribe={subscribe}
-        onStateChange={updateState}
-        fields={fields}
-        validate={validate}
-        commands={commands}
-        consumer={consumer}
-      />,
-      dom
-    )
-);
+export const createReactRenderer = <FieldAttrs extends TFields>(
+  defaultFields: FieldAttrs
+) =>
+  mount<FieldAttrs, ReactElement>(
+    (
+      consumer,
+      validate,
+      dom,
+      nestedEditors,
+      updateState,
+      fields,
+      commands,
+      subscribe
+    ) =>
+      render(
+        <EmbedProvider
+          subscribe={subscribe}
+          onStateChange={updateState}
+          defaultFields={defaultFields}
+          fields={fields}
+          validate={validate}
+          commands={commands}
+          consumer={consumer}
+          nestedEditors={nestedEditors}
+        />,
+        dom
+      )
+  );

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -15,7 +15,7 @@ import { DecorationSet, EditorView } from "prosemirror-view";
 export class RTENodeView<LocalSchema extends Schema> {
   // The parent DOM element for this view. Public
   // so it can be mounted by consuming elements.
-  public dom = document.createElement("div");
+  public nodeViewElement = document.createElement("div");
   // The editor view for this NodeView.
   private innerEditorView: EditorView | undefined;
   // The decorations that apply to this NodeView.
@@ -45,19 +45,19 @@ export class RTENodeView<LocalSchema extends Schema> {
     }
     this.innerEditorView.destroy();
     this.innerEditorView = undefined;
-    this.dom.textContent = "";
+    this.nodeViewElement.textContent = "";
   }
 
   public update(
     node: Node,
     decorations: DecorationSet | Decoration[],
-    offset: number
+    elementOffset: number
   ) {
     if (!node.sameMarkup(this.node)) {
       return false;
     }
 
-    this.updateInnerEditor(node, decorations, offset);
+    this.updateInnerEditor(node, decorations, elementOffset);
 
     return true;
   }
@@ -95,9 +95,9 @@ export class RTENodeView<LocalSchema extends Schema> {
   private updateInnerEditor(
     node: Node,
     decorations: DecorationSet | Decoration[],
-    offset: number
+    elementOffset: number
   ) {
-    this.offset = offset;
+    this.offset = elementOffset;
     this.node = node;
     this.applyDecorationsFromOuterEditor(decorations);
 
@@ -172,7 +172,7 @@ export class RTENodeView<LocalSchema extends Schema> {
   }
 
   private createInnerEditorView(schema: Schema) {
-    return new EditorView<LocalSchema>(this.dom, {
+    return new EditorView<LocalSchema>(this.nodeViewElement, {
       state: EditorState.create<LocalSchema>({
         doc: this.node,
         plugins: [

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -48,7 +48,11 @@ export class RTENodeView<LocalSchema extends Schema> {
     this.dom.textContent = "";
   }
 
-  public update(node: Node, decorations: DecorationSet, offset: number) {
+  public update(
+    node: Node,
+    decorations: DecorationSet | Decoration[],
+    offset: number
+  ) {
     if (!node.sameMarkup(this.node)) {
       return false;
     }
@@ -86,7 +90,7 @@ export class RTENodeView<LocalSchema extends Schema> {
 
   private updateInnerEditor(
     node: Node,
-    decorations: DecorationSet,
+    decorations: DecorationSet | Decoration[],
     offset: number
   ) {
     this.offset = offset;
@@ -186,7 +190,7 @@ export class RTENodeView<LocalSchema extends Schema> {
     const localDecoSet =
       decorationSet instanceof DecorationSet
         ? decorationSet
-        : DecorationSet.create(this.innerEditorView.state.doc, decorationSet);
+        : DecorationSet.create(this.node, decorationSet);
     const offsetMap = new Mapping([StepMap.offset(-this.offset - 1)]);
     this.decorations = localDecoSet.map(offsetMap, this.node);
   }

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -169,10 +169,6 @@ export class RTENodeView<LocalSchema extends Schema> {
     innerState: EditorState,
     transactions: Transaction[]
   ) {
-    if (typeof this.getPos === "boolean") {
-      return;
-    }
-
     const outerTr = this.outerView.state.tr;
     // When we insert content, we must offset to account for a few things:
     //  - getPos() returns the position directly before the parent node (+1)

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -3,7 +3,7 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { Node, Schema } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
-import { EditorState, TextSelection } from "prosemirror-state";
+import { EditorState } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
 import type { Decoration } from "prosemirror-view";
 import { DecorationSet, EditorView } from "prosemirror-view";

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -81,11 +81,15 @@ export class RTENodeView<LocalSchema extends Schema> {
     const { state, transactions } = this.innerEditorView.state.applyTransaction(
       tr
     );
-    this.innerEditorView.updateState(state);
 
+    // Applying the outer state first ensures that decorations in the parent
+    // view are correctly mapped through this transaction by the time they're
+    // accessed by the innerEditorView.
     if (!tr.getMeta("fromOutside")) {
       this.updateOuterEditor(tr, state, transactions);
     }
+
+    this.innerEditorView.updateState(state);
   }
 
   private updateInnerEditor(

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -3,7 +3,7 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { Node, Schema } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
-import { EditorState } from "prosemirror-state";
+import { EditorState, TextSelection } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
 import type { Decoration } from "prosemirror-view";
 import { DecorationSet, EditorView } from "prosemirror-view";

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -1,0 +1,193 @@
+import { exampleSetup } from "prosemirror-example-setup";
+import { redo, undo } from "prosemirror-history";
+import { keymap } from "prosemirror-keymap";
+import type { Node, Schema } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+import { EditorState } from "prosemirror-state";
+import { Mapping, StepMap } from "prosemirror-transform";
+import type { Decoration } from "prosemirror-view";
+import { DecorationSet, EditorView } from "prosemirror-view";
+
+/**
+ * A NodeView (https://prosemirror.net/docs/ref/#view.NodeView) that represents a
+ * nested rich text editor interface.
+ */
+export class RTENodeView<LocalSchema extends Schema> {
+  // The parent DOM element for this view. Public
+  // so it can be mounted by consuming elements.
+  public dom = document.createElement("div");
+  // The editor view for this NodeView.
+  private innerEditorView: EditorView | undefined;
+  // The decorations that apply to this NodeView.
+  private decorations = new DecorationSet();
+
+  constructor(
+    // The node that this NodeView is responsible for rendering.
+    private node: Node,
+    // The outer editor instance. Updated from within this class when the inner state changes.
+    private outerView: EditorView,
+    // Returns the current position of the node in the document.
+    private getPos: boolean | (() => number),
+    // @todo
+    private offset: number,
+    // The schema that the internal editor should use.
+    schema: Schema,
+    // The initial decorations for the NodeView.
+    decorations: DecorationSet | Decoration[]
+  ) {
+    this.applyDecorationsFromOuterEditor(decorations);
+    this.innerEditorView = this.createInnerEditorView(schema);
+  }
+
+  public close() {
+    if (!this.innerEditorView) {
+      return;
+    }
+    this.innerEditorView.destroy();
+    this.innerEditorView = undefined;
+    this.dom.textContent = "";
+  }
+
+  public update(node: Node, decorations: DecorationSet, offset: number) {
+    if (!node.sameMarkup(this.node)) {
+      return false;
+    }
+
+    this.updateInnerEditor(node, decorations, offset);
+
+    return true;
+  }
+
+  public destroy() {
+    if (this.innerEditorView) this.close();
+  }
+
+  /**
+   * Prevent events received in the inner editor from propagating to the outer editor.
+   */
+  public stopEvent(event: Event) {
+    return this.innerEditorView?.dom.contains(event.target as HTMLElement);
+  }
+
+  private onInnerStateChange(tr: Transaction) {
+    if (!this.innerEditorView) {
+      return;
+    }
+
+    const { state, transactions } = this.innerEditorView.state.applyTransaction(
+      tr
+    );
+    this.innerEditorView.updateState(state);
+
+    if (!tr.getMeta("fromOutside")) {
+      this.updateOuterEditor(tr, state, transactions);
+    }
+  }
+
+  private updateInnerEditor(
+    node: Node,
+    decorations: DecorationSet,
+    offset: number
+  ) {
+    this.offset = offset;
+    this.node = node;
+    this.applyDecorationsFromOuterEditor(decorations);
+
+    if (!this.innerEditorView) {
+      return;
+    }
+
+    const state = this.innerEditorView.state;
+    const start = node.content.findDiffStart(state.doc.content);
+
+    if (start === null || start === undefined) {
+      return;
+    }
+
+    const diffEnd = node.content.findDiffEnd(state.doc.content);
+    if (!diffEnd) {
+      return;
+    }
+
+    let { a: endA, b: endB } = diffEnd;
+    const overlap = start - Math.min(endA, endB);
+    if (overlap > 0) {
+      endA += overlap;
+      endB += overlap;
+    }
+
+    this.innerEditorView.dispatch(
+      state.tr
+        .replace(start, endB, node.slice(start, endA))
+        .setMeta("fromOutside", true)
+    );
+  }
+
+  private updateOuterEditor(
+    innerTr: Transaction,
+    state: EditorState,
+    transactions: Transaction[]
+  ) {
+    if (typeof this.getPos === "boolean") {
+      return;
+    }
+
+    const outerTr = this.outerView.state.tr;
+    // @todo why this magic number?
+    const offsetMap = StepMap.offset(this.getPos() + this.offset + 2);
+    for (let i = 0; i < transactions.length; i++) {
+      const steps = transactions[i].steps;
+      for (let j = 0; j < steps.length; j++) {
+        const mappedStep = steps[j].map(offsetMap);
+        if (mappedStep) {
+          outerTr.step(mappedStep);
+        }
+      }
+    }
+
+    const selection = state.selection;
+    const mappedSelection = selection.map(outerTr.doc, offsetMap);
+
+    const selectionHasChanged = !outerTr.selection.eq(mappedSelection);
+    if (selectionHasChanged) {
+      outerTr.setSelection(mappedSelection);
+    }
+
+    const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged;
+
+    if (shouldUpdateOuter) this.outerView.dispatch(outerTr);
+  }
+
+  private createInnerEditorView(schema: Schema) {
+    return new EditorView<LocalSchema>(this.dom, {
+      state: EditorState.create<LocalSchema>({
+        doc: this.node,
+        plugins: [
+          keymap({
+            "Mod-z": () => undo(this.outerView.state, this.outerView.dispatch),
+            "Mod-y": () => redo(this.outerView.state, this.outerView.dispatch),
+          }),
+          ...exampleSetup({ schema }),
+        ],
+      }),
+      // The EditorView defers state management to this class rather than handling changes itself.
+      // This lets us propagate changes to the outer EditorView when needed.
+      dispatchTransaction: this.onInnerStateChange.bind(this),
+      decorations: () => this.decorations,
+    });
+  }
+
+  private applyDecorationsFromOuterEditor(
+    decorationSet: DecorationSet | Decoration[]
+  ) {
+    if (!this.innerEditorView) {
+      return;
+    }
+    const localDecoSet =
+      decorationSet instanceof DecorationSet
+        ? decorationSet
+        : DecorationSet.create(this.innerEditorView.state.doc, decorationSet);
+    const offsetMap = new Mapping([StepMap.offset(-this.offset - 1)]);
+    this.decorations = localDecoSet.map(offsetMap, this.node);
+  }
+}

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -129,7 +129,7 @@ export class RTENodeView<LocalSchema extends Schema> {
 
   private updateOuterEditor(
     innerTr: Transaction,
-    state: EditorState,
+    innerState: EditorState,
     transactions: Transaction[]
   ) {
     if (typeof this.getPos === "boolean") {
@@ -149,7 +149,7 @@ export class RTENodeView<LocalSchema extends Schema> {
       }
     }
 
-    const selection = state.selection;
+    const selection = innerState.selection;
     const mappedSelection = selection.map(outerTr.doc, offsetMap);
 
     const selectionHasChanged = !outerTr.selection.eq(mappedSelection);

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -27,7 +27,7 @@ export class RTENodeView<LocalSchema extends Schema> {
     // The outer editor instance. Updated from within this class when the inner state changes.
     private outerView: EditorView,
     // Returns the current position of the parent Nodeview in the document.
-    private getPos: boolean | (() => number),
+    private getPos: () => number,
     // The offset of this node relative to its parent NodeView.
     private offset: number,
     // The schema that the internal editor should use.

--- a/src/nodeViews/RTENode.ts
+++ b/src/nodeViews/RTENode.ts
@@ -66,13 +66,6 @@ export class RTENodeView<LocalSchema extends Schema> {
     if (this.innerEditorView) this.close();
   }
 
-  /**
-   * Prevent events received in the inner editor from propagating to the outer editor.
-   */
-  public stopEvent(event: Event) {
-    return this.innerEditorView?.dom.contains(event.target as HTMLElement);
-  }
-
   private onInnerStateChange(tr: Transaction) {
     if (!this.innerEditorView) {
       return;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,17 +8,13 @@ import type { Commands } from "./helpers";
 import { createDecorations } from "./helpers";
 import { RTENodeView } from "./nodeViews/RTENode";
 import type { NestedEditorMap, TEmbed } from "./types/Embed";
-import type { TFields } from "./types/Fields";
 
 const decorations = createDecorations("imageEmbed");
 
 export type PluginState = { hasErrors: boolean };
 
-export const createPlugin = <
-  FieldAttrs extends TFields,
-  LocalSchema extends Schema = Schema
->(
-  embedsSpec: GenericEmbedsSpec<FieldAttrs>,
+export const createPlugin = <LocalSchema extends Schema = Schema>(
+  embedsSpec: GenericEmbedsSpec,
   commands: Commands
 ): Plugin<PluginState, LocalSchema> => {
   type EmbedNode = Node<LocalSchema>;
@@ -55,8 +51,8 @@ export const createPlugin = <
 
 type NodeViewSpec = NonNullable<EditorProps["nodeViews"]>;
 
-const createNodeViews = <FieldAttrs extends TFields>(
-  embedsSpec: GenericEmbedsSpec<FieldAttrs>,
+const createNodeViews = (
+  embedsSpec: GenericEmbedsSpec,
   commands: Commands
 ): NodeViewSpec => {
   const nodeViews = {} as NodeViewSpec;
@@ -73,9 +69,9 @@ const createNodeViews = <FieldAttrs extends TFields>(
 
 type NodeViewCreator = NodeViewSpec[keyof NodeViewSpec];
 
-const createNodeView = <FieldAttrs extends TFields>(
+const createNodeView = (
   embedName: string,
-  createEmbed: TEmbed<FieldAttrs>,
+  createEmbed: TEmbed,
   commands: Commands
 ): NodeViewCreator => (initNode, view, _getPos, _, innerDecos) => {
   const dom = document.createElement("div");

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,17 +1,25 @@
-import type { Node, Schema } from "prosemirror-model";
+import type { Node } from "prosemirror-model";
+import { Schema } from "prosemirror-model";
+import { schema } from "prosemirror-schema-basic";
 import { Plugin } from "prosemirror-state";
-import type { buildCommands } from "./helpers";
-import { createDecorations } from "./helpers";
-import type { TEmbed } from "./types/Embed";
+import type { EditorProps } from "prosemirror-view";
+import type { GenericEmbedsSpec } from "./embed";
+import type { TPredicate } from "./helpers";
+import { buildCommands, createDecorations } from "./helpers";
+import { RTENodeView } from "./nodeViews/RTENode";
+import type { NestedEditorMap, TEmbed } from "./types/Embed";
 import type { TFields } from "./types/Fields";
 
 const decorations = createDecorations("embed");
 
 export type PluginState = { hasErrors: boolean };
 
-export const createPlugin = <LocalSchema extends Schema>(
-  types: Record<string, TEmbed<TFields>>,
-  commands: ReturnType<typeof buildCommands>
+export const createPlugin = <
+  FieldAttrs extends TFields,
+  LocalSchema extends Schema = Schema
+>(
+  embedsSpec: GenericEmbedsSpec<FieldAttrs>,
+  predicate: TPredicate
 ): Plugin<PluginState, LocalSchema> => {
   type EmbedNode = Node<LocalSchema>;
 
@@ -40,48 +48,96 @@ export const createPlugin = <LocalSchema extends Schema>(
     },
     props: {
       decorations,
-      nodeViews: {
-        embed: (initNode: EmbedNode, view, getPos) => {
-          const dom = document.createElement("div");
-          dom.contentEditable = "false";
-          const mount = types[initNode.attrs.type as string];
-          const pos = typeof getPos === "boolean" ? 0 : getPos();
-
-          const update = mount(
-            dom,
-            (fields: Record<string, string>, hasErrors: boolean) => {
-              view.dispatch(
-                view.state.tr.setNodeMarkup(pos, undefined, {
-                  ...initNode.attrs,
-                  fields,
-                  hasErrors,
-                })
-              );
-            },
-            initNode.attrs.fields,
-            commands(pos, view.state, view.dispatch)
-          );
-
-          return {
-            dom,
-            update: (node: EmbedNode) => {
-              if (
-                node.type.name === "embed" &&
-                node.attrs.type === initNode.attrs.type
-              ) {
-                update(
-                  node.attrs.fields,
-                  commands(pos, view.state, view.dispatch)
-                );
-                return true;
-              }
-              return false;
-            },
-            stopEvent: () => true,
-            destroy: () => null,
-          };
-        },
-      },
+      nodeViews: createNodeViews(embedsSpec, predicate),
     },
   });
+};
+
+type NodeViewSpec = NonNullable<EditorProps["nodeViews"]>;
+
+const createNodeViews = <FieldAttrs extends TFields>(
+  embedsSpec: GenericEmbedsSpec<FieldAttrs>,
+  predicate: TPredicate
+): NodeViewSpec => {
+  const nodeViews = {} as NodeViewSpec;
+  for (const embedName in embedsSpec) {
+    nodeViews[embedName] = createNodeView(
+      embedName,
+      embedsSpec[embedName],
+      predicate
+    );
+  }
+
+  return nodeViews;
+};
+
+type NodeViewCreator = NodeViewSpec[keyof NodeViewSpec];
+
+const createNodeView = <FieldAttrs extends TFields>(
+  embedName: string,
+  createEmbed: TEmbed<FieldAttrs>,
+  predicate: TPredicate
+): NodeViewCreator => (initNode, view, getPos, innerDecos) => {
+  const dom = document.createElement("div");
+  dom.contentEditable = "false";
+  const pos = typeof getPos === "boolean" ? 0 : getPos();
+
+  const nestedEditors = {} as NestedEditorMap;
+  const temporaryHardcodedSchema = new Schema({
+    nodes: schema.spec.nodes,
+    marks: schema.spec.marks,
+  });
+
+  initNode.forEach((node, offset) => {
+    const typeName = node.type.name;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- unsure why this triggers
+    if (nestedEditors[typeName]) {
+      console.error(
+        `[prosemirror-embeds]: Attempted to instantiate a nested editor with type ${typeName}, but another instance with that name has already been created.`
+      );
+    }
+    nestedEditors[typeName] = new RTENodeView(
+      node,
+      view,
+      getPos,
+      offset,
+      temporaryHardcodedSchema,
+      innerDecos
+    );
+  });
+
+  const update = createEmbed(
+    dom,
+    nestedEditors,
+    (fields, hasErrors) => {
+      view.dispatch(
+        view.state.tr.setNodeMarkup(pos, undefined, {
+          ...initNode.attrs,
+          fields,
+          hasErrors,
+        })
+      );
+    },
+    initNode.attrs.fields,
+    buildCommands(predicate, pos, view.state, view.dispatch)
+  );
+
+  return {
+    dom,
+    update: (node: Node) => {
+      if (
+        node.type.name === embedName &&
+        node.attrs.type === initNode.attrs.type
+      ) {
+        update(
+          node.attrs.fields,
+          buildCommands(predicate, pos, view.state, view.dispatch)
+        );
+        return true;
+      }
+      return false;
+    },
+    stopEvent: () => true,
+    destroy: () => null,
+  };
 };

--- a/src/prosemirrorSetup.ts
+++ b/src/prosemirrorSetup.ts
@@ -1,0 +1,29 @@
+// Mix the nodes from prosemirror-schema-list into the basic schema to
+
+import type OrderedMap from "orderedmap";
+import type { Node, NodeSpec } from "prosemirror-model";
+import { DOMParser, DOMSerializer, Schema } from "prosemirror-model";
+import { schema } from "prosemirror-schema-basic";
+import { addEmbedNode } from "./embed";
+
+// create a schema with list support.
+export const mySchema = new Schema({
+  nodes: addEmbedNode(schema.spec.nodes as OrderedMap<NodeSpec>),
+  marks: schema.spec.marks,
+});
+
+const parser = DOMParser.fromSchema(mySchema);
+const serializer = DOMSerializer.fromSchema(mySchema);
+
+export const docToHtml = (doc: Node) => {
+  const dom = serializer.serializeFragment(doc.content);
+  const e = document.createElement("div");
+  e.appendChild(dom);
+  return e.innerHTML;
+};
+
+export const htmlToDoc = (html: string) => {
+  const dom = document.createElement("div");
+  dom.innerHTML = html;
+  return parser.parse(dom);
+};

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -2,9 +2,9 @@ import type { NestedEditorMap } from "./Embed";
 import type { TErrors } from "./Errors";
 import type { TFields } from "./Fields";
 
-export type TConsumer<ConsumerResult, FieldAttrs extends TFields> = (
-  fields: FieldAttrs,
+export type TConsumer<ConsumerResult> = (
+  fields: TFields,
   errors: TErrors,
-  updateFields: (fields: Partial<FieldAttrs>) => void,
+  updateFields: (fields: TFields) => void,
   nestedEditors: NestedEditorMap
 ) => ConsumerResult;

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -1,8 +1,10 @@
+import type { NestedEditorMap } from "./Embed";
 import type { TErrors } from "./Errors";
 import type { TFields } from "./Fields";
 
 export type TConsumer<ConsumerResult, FieldAttrs extends TFields> = (
   fields: FieldAttrs,
   errors: TErrors,
-  updateFields: (fields: FieldAttrs) => void
+  updateFields: (fields: Partial<FieldAttrs>) => void,
+  nestedEditors: NestedEditorMap
 ) => ConsumerResult;

--- a/src/types/Embed.ts
+++ b/src/types/Embed.ts
@@ -8,10 +8,10 @@ export type NestedEditorMap<LocalSchema extends Schema = Schema> = Record<
   RTENodeView<LocalSchema>
 >;
 
-export type TEmbed<FieldAttrs extends TFields> = (
+export type TEmbed = (
   dom: HTMLElement,
   nestedEditors: NestedEditorMap,
-  updateState: (fields: Partial<FieldAttrs>, hasErrors: boolean) => void,
-  initFields: FieldAttrs,
+  updateState: (fields: TFields, hasErrors: boolean) => void,
+  initFields: TFields,
   commands: ReturnType<TCommandCreator>
-) => (fields: FieldAttrs, commands: ReturnType<TCommandCreator>) => void;
+) => (fields: TFields, commands: ReturnType<TCommandCreator>) => void;

--- a/src/types/Embed.ts
+++ b/src/types/Embed.ts
@@ -1,11 +1,17 @@
-// @todo: placeholder
-
+import type { Schema } from "prosemirror-model";
+import type { RTENodeView } from "../nodeViews/RTENode";
 import type { TCommandCreator } from "./Commands";
 import type { TFields } from "./Fields";
 
+export type NestedEditorMap<LocalSchema extends Schema = Schema> = Record<
+  string,
+  RTENodeView<LocalSchema>
+>;
+
 export type TEmbed<FieldAttrs extends TFields> = (
   dom: HTMLElement,
-  updateState: (fields: TFields, hasErrors: boolean) => void,
+  nestedEditors: NestedEditorMap,
+  updateState: (fields: Partial<FieldAttrs>, hasErrors: boolean) => void,
   initFields: FieldAttrs,
   commands: ReturnType<TCommandCreator>
 ) => (fields: FieldAttrs, commands: ReturnType<TCommandCreator>) => void;

--- a/src/types/Validator.ts
+++ b/src/types/Validator.ts
@@ -1,5 +1,5 @@
 import type { TFields } from "./Fields";
 
 export type TValidator<FieldAttrs extends TFields> = (
-  fields: FieldAttrs
+  fields: Partial<FieldAttrs>
 ) => null | Record<string, string[]>;

--- a/src/types/Validator.ts
+++ b/src/types/Validator.ts
@@ -1,5 +1,3 @@
 import type { TFields } from "./Fields";
 
-export type TValidator<FieldAttrs extends TFields> = (
-  fields: Partial<FieldAttrs>
-) => null | Record<string, string[]>;
+export type TValidator = (fields: TFields) => null | Record<string, string[]>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,7 @@
     "lib": ["dom", "ESNext"],
     "types": ["cypress"],
     "sourceMap": true,
-    "strictFunctionTypes": false,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "strictNullChecks": true,
+    "strict": true,
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,6 +470,18 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
+"@hapi/hoek@^9.0.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -497,6 +509,23 @@
   integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
   dependencies:
     any-observable "^0.3.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@types/chai@^4.2.15":
   version "4.2.15"
@@ -1145,6 +1174,13 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 babel-plugin-emotion@^9.2.11:
   version "9.2.11"
@@ -2631,6 +2667,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
   integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
 
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3447,6 +3488,17 @@ jest-worker@^26.6.2:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+joi@^17.3.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20"
+  integrity sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -4930,6 +4982,13 @@ rxjs@^6.3.3:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.6.3:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -5816,6 +5875,17 @@ w3c-keyname@^2.2.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.4.tgz#4ade6916f6290224cdbd1db8ac49eab03d0eef6b"
   integrity sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==
+
+wait-on@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"
+  integrity sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==
+  dependencies:
+    axios "^0.21.1"
+    joi "^17.3.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    rxjs "^6.6.3"
 
 watchpack@^2.0.0:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4573,10 +4573,19 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transfor
   dependencies:
     prosemirror-model "^1.0.0"
 
-prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.18.0:
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.18.0.tgz#92d27b2583877938c529e173e6e3a0f3f6aa0e1c"
   integrity sha512-UoY29oeWruT6RKhH7wGytUBVrlaszNx43wvOxZPCMjYPvKBT21EIXR8Ezr/3XstvFVBQAWdDh6Ke0qHmF43y/A==
+  dependencies:
+    prosemirror-model "^1.1.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
+
+prosemirror-view@^1.18.4:
+  version "1.18.4"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.18.4.tgz#179141df117cf414434ade08115f2e233d135f6d"
+  integrity sha512-6oi62XRK5WxhMX1Amjk5uMsWILUEcFbFF75i09BzpAdI+5glhs7heCaRvKOj4v3YRJ7LJVkOXS9xvjetlE3+pA==
   dependencies:
     prosemirror-model "^1.1.0"
     prosemirror-state "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,7 +610,7 @@
   dependencies:
     "@types/prosemirror-model" "*"
 
-"@types/prosemirror-view@*", "@types/prosemirror-view@^1.17.1":
+"@types/prosemirror-view@*":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/prosemirror-view/-/prosemirror-view-1.17.1.tgz#0895df5a57ae6e68d4f3f8020d9be4ef52192980"
   integrity sha512-PNiGGc6BffxHQzMR09UUilsBR8xFPDsKiPIXb4K/g56voPIvqq1pqySnWFfSR50Vo4ZL0tss3VBLWiiiKzVahQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,10 +1733,10 @@ cypress-webpack-preprocessor-v5@^5.0.0-alpha.1:
     debug "^4.1.1"
     lodash "^4.17.20"
 
-cypress@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.6.0.tgz#659c64cdb06e51b6be18fdac39d8f192deb54fa0"
-  integrity sha512-+Xx3Zn653LJHUsCb9h1Keql2jlazbr1ROmbY6DFJMmXKLgXP4ez9cE403W93JNGRbZK0Tng3R/oP8mvd9XAPVg==
+cypress@6.8:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.8.0.tgz#8338f39212a8f71e91ff8c017a1b6e22d823d8c1"
+  integrity sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
## What does this change?

Adds an RTENodeView to the element declarations. This allows to add data to element that's modelled in the Prosemirror schema as text.

### What does that mean?

This plugin currently models element state as flat fields on a Prosemirror node. This limits our ability to manage these fields in a collaborative editing environment. This PR adds the ability to model a property as a child node. For more information, see [the ADR detailing the approach.](https://github.com/guardian/prosemirror-embeds/blob/main/docs/decision-records/000-embed-fields-model.md#3-model-all-text-fields-as-child-nodes-with-nested-editors)

### Other notes

We'll need to do additional work to allow the schema we're adding to be a) customisable and b) dynamically computed, but this PR is already likely to be quite large! That'll be a separate piece of work.

## How to test

The automated tests should pass. Running with with `yarn test`, you should see them checking:

- element addition, movement and removal
- typing into embed fields, including styling
- that the model saved by the element is correctly represented as a node, not a field.

Is the code reasonably clear? Could it be clarifying with supporting comments or documentation?
