### PR TITLE
Remove Fields (flat state) in favour of Props (nested state), which are now called ... Fields

### DIFF
--- a/src/__tests__/embed.spec.ts
+++ b/src/__tests__/embed.spec.ts
@@ -1,0 +1,38 @@
+import { buildEmbedPlugin } from "../embed";
+import { createNoopEmbed } from "./helpers";
+
+describe("buildEmbedPlugin", () => {
+  describe("Typesafety", () => {
+    it("should allow consumers to instantiate embeds", () => {
+      const testEmbed = createNoopEmbed("testEmbed", {});
+      const { insertEmbed } = buildEmbedPlugin([testEmbed]);
+      insertEmbed("testEmbed", {});
+    });
+
+    it("should not allow consumers to instantiate embeds that do not exist", () => {
+      const testEmbed = createNoopEmbed("testEmbed", {});
+      const { insertEmbed } = buildEmbedPlugin([testEmbed]);
+      // @ts-expect-error -- we should not be able to insert a non-existent embed
+      insertEmbed("testEmbedThatDoesNotExist", {});
+    });
+
+    it("should allow consumers to instantiate embeds with a partial set of initial fields", () => {
+      const testEmbed = createNoopEmbed("testEmbed", {
+        prop1: { type: "richText" },
+      });
+      const { insertEmbed } = buildEmbedPlugin([testEmbed]);
+      insertEmbed("testEmbed", { prop1: "<p>Example initial state</p>" });
+    });
+
+    it("should not allow consumers to instantiate embeds with fields that do not exist", () => {
+      const testEmbed = createNoopEmbed("testEmbed", {
+        prop1: { type: "richText" },
+      });
+      const { insertEmbed } = buildEmbedPlugin([testEmbed]);
+      insertEmbed("testEmbed", {
+        // @ts-expect-error -- we should not be able to insert a non-existent field
+        propDoesNotExist: "<p>Example initial state</p>",
+      });
+    });
+  });
+});

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,19 +1,19 @@
 import { mount } from "../mount";
-import type { EmbedProps } from "../types/Embed";
+import type { FieldSpec } from "../types/Embed";
 
 /**
  * Create an embed which renders nothing. Useful when testing schema output.
  */
 export const createNoopEmbed = <
   Name extends string,
-  Props extends EmbedProps<string>
+  FSpec extends FieldSpec<string>
 >(
   name: Name,
-  props: Props
+  fieldSpec: FSpec
 ) =>
   mount(
     name,
-    props,
+    fieldSpec,
     () => () => null,
     () => null,
     () => null,

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,10 +1,10 @@
 import { mount } from "../mount";
-import type { ElementProps } from "../types/Embed";
+import type { EmbedProps } from "../types/Embed";
 
 /**
  * Create an embed which renders nothing. Useful when testing schema output.
  */
-export const createNoopEmbed = (name: string, props: ElementProps) =>
+export const createNoopEmbed = (name: string, props: EmbedProps<string>) =>
   mount(
     name,
     props,

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -4,7 +4,13 @@ import type { EmbedProps } from "../types/Embed";
 /**
  * Create an embed which renders nothing. Useful when testing schema output.
  */
-export const createNoopEmbed = (name: string, props: EmbedProps<string>) =>
+export const createNoopEmbed = <
+  Name extends string,
+  Props extends EmbedProps<string>
+>(
+  name: Name,
+  props: Props
+) =>
   mount(
     name,
     props,

--- a/src/__tests__/mount.spec.ts
+++ b/src/__tests__/mount.spec.ts
@@ -50,6 +50,10 @@ describe("mount", () => {
         prop1: {
           type: "richText",
         },
+        prop2: {
+          type: "checkbox",
+          defaultValue: true,
+        },
       } as const;
       mount(
         "testEmbed",
@@ -58,6 +62,8 @@ describe("mount", () => {
         (fields) => {
           // Prop1 is derived from the fieldSpec, and is a string b/c it's a richText field
           fields.prop1.toString();
+          // Prop2 is a boolean b/c it's a checkbox field
+          fields.prop2.value.valueOf();
         },
         () => null,
         { prop1: "text" }
@@ -117,22 +123,50 @@ describe("mount", () => {
       expect(nodeSpec.get("prop2")).toMatchObject({ content: "paragraph" });
     });
 
-    it("should allow the user to specify custom toDOM and parseDOM properties on richText props", () => {
-      const fieldSpec = {
-        prop1: {
-          type: "richText" as const,
-          content: "text",
-          toDOM: () => "div",
-          parseDOM: [{ tag: "header" }],
-        },
-      };
+    describe("fields", () => {
+      describe("richText", () => {
+        it("should allow the user to specify custom toDOM and parseDOM properties on richText props", () => {
+          const fieldSpec = {
+            prop1: {
+              type: "richText" as const,
+              content: "text",
+              toDOM: () => "div",
+              parseDOM: [{ tag: "header" }],
+            },
+          };
 
-      const testEmbed1 = createNoopEmbed("testEmbed1", fieldSpec);
-      const { nodeSpec } = buildEmbedPlugin([testEmbed1]);
-      expect(nodeSpec.get("prop1")).toEqual({
-        content: fieldSpec.prop1.content,
-        toDOM: fieldSpec.prop1.toDOM,
-        parseDOM: fieldSpec.prop1.parseDOM,
+          const testEmbed1 = createNoopEmbed("testEmbed1", fieldSpec);
+          const { nodeSpec } = buildEmbedPlugin([testEmbed1]);
+          expect(nodeSpec.get("prop1")).toEqual({
+            content: fieldSpec.prop1.content,
+            toDOM: fieldSpec.prop1.toDOM,
+            parseDOM: fieldSpec.prop1.parseDOM,
+          });
+        });
+      });
+
+      describe("checkbox", () => {
+        it("should specify the appropriate fields on checkbox props", () => {
+          const fieldSpec = {
+            prop1: {
+              type: "checkbox" as const,
+              defaultValue: true,
+            },
+          };
+
+          const testEmbed1 = createNoopEmbed("testEmbed1", fieldSpec);
+          const { nodeSpec } = buildEmbedPlugin([testEmbed1]);
+          expect(nodeSpec.get("prop1")).toMatchObject({
+            atom: true,
+            attrs: {
+              fields: {
+                default: {
+                  value: true,
+                },
+              },
+            },
+          });
+        });
       });
     });
   });

--- a/src/__tests__/mount.spec.ts
+++ b/src/__tests__/mount.spec.ts
@@ -3,20 +3,20 @@ import { mount } from "../mount";
 import { createNoopEmbed } from "./helpers";
 
 describe("mount", () => {
-  describe("nestedEditorProps typesafety", () => {
-    it("should provide typesafe nestedEditorProps to its consumer", () => {
-      const props = {
+  describe("nodeView typesafety", () => {
+    it("should provide typesafe nodeView to its consumer", () => {
+      const fieldSpec = {
         prop1: {
           type: "richText",
         },
       } as const;
       mount(
         "testEmbed",
-        props,
+        fieldSpec,
         () => () => null,
-        (_, __, ___, nestedEditorProps) => {
-          // Prop1 is derived from the props
-          nestedEditorProps.prop1;
+        (_, __, ___, fieldNodeViews) => {
+          // Prop1 is derived from the fieldSpec
+          fieldNodeViews.prop1;
         },
         () => null,
         { prop1: "text" }
@@ -24,25 +24,67 @@ describe("mount", () => {
     });
 
     it("should not typecheck when props are not provided", () => {
-      const props = {
+      const fieldSpec = {
         notProp1: {
           type: "richText",
         },
       } as const;
       mount(
         "testEmbed",
-        props,
+        fieldSpec,
         () => () => null,
-        (_, __, ___, nestedEditorProps) => {
+        (_, __, ___, fieldNodeViews) => {
           // @ts-expect-error – prop1 is not available on this object,
-          // as it is not defined in `props` passed into `mount`
-          nestedEditorProps.prop1;
+          // as it is not defined in `fieldSpec` passed into `mount`
+          fieldNodeViews.prop1;
         },
         () => null,
         { notProp1: "text" }
       );
     });
   });
+
+  describe("field typesafety", () => {
+    it("should provide typesafe fields to its consumer", () => {
+      const fieldSpec = {
+        prop1: {
+          type: "richText",
+        },
+      } as const;
+      mount(
+        "testEmbed",
+        fieldSpec,
+        () => () => null,
+        (fields) => {
+          // Prop1 is derived from the fieldSpec, and is a string b/c it's a richText field
+          fields.prop1.toString();
+        },
+        () => null,
+        { prop1: "text" }
+      );
+    });
+
+    it("should not typecheck when props are not provided", () => {
+      const fieldSpec = {
+        notProp1: {
+          type: "richText",
+        },
+      } as const;
+      mount(
+        "testEmbed",
+        fieldSpec,
+        () => () => null,
+        (fields) => {
+          // @ts-expect-error – prop1 is not available on this object,
+          // as it is not defined in `fieldSpec` passed into `mount`
+          fields.doesNotExist;
+        },
+        () => null,
+        { notProp1: "text" }
+      );
+    });
+  });
+
   describe("nodeSpec generation", () => {
     it("should create an nodeSpec with no nodes when the spec is empty", () => {
       const { nodeSpec } = buildEmbedPlugin([]);
@@ -76,7 +118,7 @@ describe("mount", () => {
     });
 
     it("should allow the user to specify custom toDOM and parseDOM properties on richText props", () => {
-      const props = {
+      const fieldSpec = {
         prop1: {
           type: "richText" as const,
           content: "text",
@@ -85,12 +127,12 @@ describe("mount", () => {
         },
       };
 
-      const testEmbed1 = createNoopEmbed("testEmbed1", props);
+      const testEmbed1 = createNoopEmbed("testEmbed1", fieldSpec);
       const { nodeSpec } = buildEmbedPlugin([testEmbed1]);
       expect(nodeSpec.get("prop1")).toEqual({
-        content: props.prop1.content,
-        toDOM: props.prop1.toDOM,
-        parseDOM: props.prop1.parseDOM,
+        content: fieldSpec.prop1.content,
+        toDOM: fieldSpec.prop1.toDOM,
+        parseDOM: fieldSpec.prop1.parseDOM,
       });
     });
   });

--- a/src/__tests__/mount.spec.ts
+++ b/src/__tests__/mount.spec.ts
@@ -6,12 +6,13 @@ describe("mount", () => {
   describe("nestedEditorProps typesafety", () => {
     it("should provide typesafe nestedEditorProps to its consumer", () => {
       const props = {
-        type: "richText",
-        name: "prop1",
+        prop1: {
+          type: "richText",
+        },
       } as const;
       mount(
         "testEmbed",
-        [props],
+        props,
         () => () => null,
         (_, __, ___, nestedEditorProps) => {
           // Prop1 is derived from the props
@@ -24,12 +25,13 @@ describe("mount", () => {
 
     it("should not typecheck when props are not provided", () => {
       const props = {
-        type: "richText",
-        name: "notProp1",
+        notProp1: {
+          type: "richText",
+        },
       } as const;
       mount(
         "testEmbed",
-        [props],
+        props,
         () => () => null,
         (_, __, ___, nestedEditorProps) => {
           // @ts-expect-error – prop1 is not available on this object,
@@ -48,8 +50,8 @@ describe("mount", () => {
     });
 
     it("should create an nodeSpec with a parent node for each embed", () => {
-      const testEmbed1 = createNoopEmbed("testEmbed1", []);
-      const testEmbed2 = createNoopEmbed("testEmbed2", []);
+      const testEmbed1 = createNoopEmbed("testEmbed1", {});
+      const testEmbed2 = createNoopEmbed("testEmbed2", {});
       const { nodeSpec } = build([testEmbed1, testEmbed2]);
       expect(nodeSpec.size).toBe(2);
       expect(nodeSpec.get("testEmbed1")).toMatchObject({ content: "" });
@@ -57,16 +59,14 @@ describe("mount", () => {
     });
 
     it("should create child nodes for each embed prop, and the parent node should include them in its content expression", () => {
-      const testEmbed1 = createNoopEmbed("testEmbed1", [
-        {
+      const testEmbed1 = createNoopEmbed("testEmbed1", {
+        prop1: {
           type: "richText",
-          name: "prop1",
         },
-        {
+        prop2: {
           type: "richText",
-          name: "prop2",
         },
-      ]);
+      });
       const { nodeSpec } = build([testEmbed1]);
       expect(nodeSpec.get("testEmbed1")).toMatchObject({
         content: "prop1 prop2",
@@ -76,20 +76,21 @@ describe("mount", () => {
     });
 
     it("should allow the user to specify custom toDOM and parseDOM properties on richText props", () => {
-      const prop = {
-        type: "richText" as const,
-        name: "prop1",
-        content: "text",
-        toDOM: () => "div",
-        parseDOM: [{ tag: "header" }],
+      const props = {
+        prop1: {
+          type: "richText" as const,
+          content: "text",
+          toDOM: () => "div",
+          parseDOM: [{ tag: "header" }],
+        },
       };
 
-      const testEmbed1 = createNoopEmbed("testEmbed1", [prop]);
+      const testEmbed1 = createNoopEmbed("testEmbed1", props);
       const { nodeSpec } = build([testEmbed1]);
-      expect(nodeSpec.get(prop.name)).toEqual({
-        content: prop.content,
-        toDOM: prop.toDOM,
-        parseDOM: prop.parseDOM,
+      expect(nodeSpec.get("prop1")).toEqual({
+        content: props.prop1.content,
+        toDOM: props.prop1.toDOM,
+        parseDOM: props.prop1.parseDOM,
       });
     });
   });

--- a/src/__tests__/mount.spec.ts
+++ b/src/__tests__/mount.spec.ts
@@ -19,7 +19,7 @@ describe("mount", () => {
           nestedEditorProps.prop1;
         },
         () => null,
-        {}
+        { prop1: "text" }
       );
     });
 
@@ -39,7 +39,7 @@ describe("mount", () => {
           nestedEditorProps.prop1;
         },
         () => null,
-        {}
+        { notProp1: "text" }
       );
     });
   });

--- a/src/__tests__/mount.spec.ts
+++ b/src/__tests__/mount.spec.ts
@@ -1,4 +1,4 @@
-import { build } from "../embed";
+import { buildEmbedPlugin } from "../embed";
 import { mount } from "../mount";
 import { createNoopEmbed } from "./helpers";
 
@@ -45,14 +45,14 @@ describe("mount", () => {
   });
   describe("nodeSpec generation", () => {
     it("should create an nodeSpec with no nodes when the spec is empty", () => {
-      const { nodeSpec } = build([]);
+      const { nodeSpec } = buildEmbedPlugin([]);
       expect(nodeSpec.size).toBe(0);
     });
 
     it("should create an nodeSpec with a parent node for each embed", () => {
       const testEmbed1 = createNoopEmbed("testEmbed1", {});
       const testEmbed2 = createNoopEmbed("testEmbed2", {});
-      const { nodeSpec } = build([testEmbed1, testEmbed2]);
+      const { nodeSpec } = buildEmbedPlugin([testEmbed1, testEmbed2]);
       expect(nodeSpec.size).toBe(2);
       expect(nodeSpec.get("testEmbed1")).toMatchObject({ content: "" });
       expect(nodeSpec.get("testEmbed2")).toMatchObject({ content: "" });
@@ -67,7 +67,7 @@ describe("mount", () => {
           type: "richText",
         },
       });
-      const { nodeSpec } = build([testEmbed1]);
+      const { nodeSpec } = buildEmbedPlugin([testEmbed1]);
       expect(nodeSpec.get("testEmbed1")).toMatchObject({
         content: "prop1 prop2",
       });
@@ -86,7 +86,7 @@ describe("mount", () => {
       };
 
       const testEmbed1 = createNoopEmbed("testEmbed1", props);
-      const { nodeSpec } = build([testEmbed1]);
+      const { nodeSpec } = buildEmbedPlugin([testEmbed1]);
       expect(nodeSpec.get("prop1")).toEqual({
         content: props.prop1.content,
         toDOM: props.prop1.toDOM,

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -2,17 +2,27 @@ import OrderedMap from "orderedmap";
 import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { buildCommands, defaultPredicate } from "./helpers";
+import type { NodeViewPropValues } from "./nodeViews/helpers";
 import { createPlugin } from "./plugin";
 import type { EmbedProps, TEmbed } from "./types/Embed";
-import type { TFields } from "./types/Fields";
 
-export const build = <Props extends EmbedProps<string>, Name extends string>(
+/**
+ * Build an embed plugin with the given embed specs, along with the schema required
+ * by those embeds, and a method to insert embeds into the document.
+ */
+export const buildEmbedPlugin = <
+  Props extends EmbedProps<string>,
+  Name extends string
+>(
   embedSpec: Array<TEmbed<Props, Name>>,
   predicate = defaultPredicate
 ) => {
   const typeNames = embedSpec.map((_) => _.name);
 
-  const insertEmbed = (type: Name, fields: TFields) => (
+  const insertEmbed = (
+    type: Name,
+    fields: Partial<NodeViewPropValues<Props>>
+  ) => (
     state: EditorState,
     dispatch: (tr: Transaction<Schema>) => void
   ): void => {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -2,26 +2,26 @@ import OrderedMap from "orderedmap";
 import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { buildCommands, defaultPredicate } from "./helpers";
-import type { NodeViewPropValues } from "./nodeViews/helpers";
+import type { FieldNameToValueMap } from "./nodeViews/helpers";
 import { createPlugin } from "./plugin";
-import type { EmbedProps, TEmbed } from "./types/Embed";
+import type { FieldSpec, TEmbed } from "./types/Embed";
 
 /**
  * Build an embed plugin with the given embed specs, along with the schema required
  * by those embeds, and a method to insert embeds into the document.
  */
 export const buildEmbedPlugin = <
-  Props extends EmbedProps<string>,
+  FSpec extends FieldSpec<string>,
   Name extends string
 >(
-  embedSpec: Array<TEmbed<Props, Name>>,
+  embedSpec: Array<TEmbed<FSpec, Name>>,
   predicate = defaultPredicate
 ) => {
   const typeNames = embedSpec.map((_) => _.name);
 
   const insertEmbed = (
     type: Name,
-    fields: Partial<NodeViewPropValues<Props>>
+    fields: Partial<FieldNameToValueMap<FSpec>>
   ) => (
     state: EditorState,
     dispatch: (tr: Transaction<Schema>) => void

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -3,10 +3,10 @@ import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { buildCommands, defaultPredicate } from "./helpers";
 import { createPlugin } from "./plugin";
-import type { ElementProps, TEmbed } from "./types/Embed";
+import type { EmbedProps, TEmbed } from "./types/Embed";
 import type { TFields } from "./types/Fields";
 
-export const build = <Props extends ElementProps, Name extends string>(
+export const build = <Props extends EmbedProps<string>, Name extends string>(
   embedSpec: Array<TEmbed<Props, Name>>,
   predicate = defaultPredicate
 ) => {

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { PropView } from "../../mounters/react/PropView";
-import type { NodeViewPropValues } from "../../nodeViews/helpers";
-import type { NodeViewPropMap } from "../../types/Embed";
+import type { FieldNameToValueMap } from "../../nodeViews/helpers";
+import type { FieldNameToNodeViewSpec } from "../../types/Embed";
 import type { imageProps } from "./embed";
 
 type Props = {
-  fields: NodeViewPropValues<typeof imageProps>;
+  fields: FieldNameToValueMap<typeof imageProps>;
   errors: Record<string, string[]>;
-  nodeViewPropMap: NodeViewPropMap<typeof imageProps>;
+  nodeViewPropMap: FieldNameToNodeViewSpec<typeof imageProps>;
 };
 
 export const ImageEmbedTestId = "ImageEmbed";

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -14,14 +14,20 @@ export const ImageEmbedTestId = "ImageEmbed";
 
 export const ImageEmbed: React.FunctionComponent<Props> = ({
   fields,
+  errors,
   nodeViewPropMap,
 }) => {
   return (
     <div data-cy={ImageEmbedTestId}>
-      {JSON.stringify(fields)}
       <PropView nodeViewProp={nodeViewPropMap.altText} />
       <PropView nodeViewProp={nodeViewPropMap.caption} />
       <PropView nodeViewProp={nodeViewPropMap.useSrc} />
+      <hr />
+      <h4>Embed errors</h4>
+      <pre>{JSON.stringify(errors)}</pre>
+      <hr />
+      <h4>Embed values</h4>
+      <pre>{JSON.stringify(fields)}</pre>
     </div>
   );
 };

--- a/src/embeds/image/ImageEmbed.tsx
+++ b/src/embeds/image/ImageEmbed.tsx
@@ -1,20 +1,24 @@
 import React from "react";
 import { PropView } from "../../mounters/react/PropView";
-import type { NodeViewPropMapFromProps } from "../../types/Embed";
+import type { NodeViewPropValues } from "../../nodeViews/helpers";
+import type { NodeViewPropMap } from "../../types/Embed";
 import type { imageProps } from "./embed";
 
 type Props = {
+  fields: NodeViewPropValues<typeof imageProps>;
   errors: Record<string, string[]>;
-  nodeViewPropMap: NodeViewPropMapFromProps<typeof imageProps>;
+  nodeViewPropMap: NodeViewPropMap<typeof imageProps>;
 };
 
 export const ImageEmbedTestId = "ImageEmbed";
 
 export const ImageEmbed: React.FunctionComponent<Props> = ({
+  fields,
   nodeViewPropMap,
 }) => {
   return (
     <div data-cy={ImageEmbedTestId}>
+      {JSON.stringify(fields)}
       <PropView nodeViewProp={nodeViewPropMap.altText} />
       <PropView nodeViewProp={nodeViewPropMap.caption} />
       <PropView nodeViewProp={nodeViewPropMap.useSrc} />

--- a/src/embeds/image/embed.tsx
+++ b/src/embeds/image/embed.tsx
@@ -25,6 +25,10 @@ export const createImageEmbed = <Name extends string>(name: Name) =>
         />
       );
     },
-    ({ altText }) => (altText ? null : { alt: ["Alt tag must be set"] }),
+    ({ altText }) => {
+      const el = document.createElement("div");
+      el.innerHTML = altText;
+      return el.innerText ? null : { altText: ["Alt tag must be set"] };
+    },
     { caption: "", useSrc: { value: true }, altText: "" }
   );

--- a/src/embeds/image/embed.tsx
+++ b/src/embeds/image/embed.tsx
@@ -16,9 +16,15 @@ export const createImageEmbed = <Name extends string>(name: Name) =>
   createReactEmbedRenderer(
     name,
     imageProps,
-    (_, errors, __, nodeViewPropMap) => {
-      return <ImageEmbed errors={errors} nodeViewPropMap={nodeViewPropMap} />;
+    (fields, errors, __, nodeViewPropMap) => {
+      return (
+        <ImageEmbed
+          fields={fields}
+          errors={errors}
+          nodeViewPropMap={nodeViewPropMap}
+        />
+      );
     },
-    ({ alt }) => (alt ? null : { alt: ["Alt tag must be set"] }),
-    { caption: "", src: "", alt: "" }
+    ({ altText }) => (altText ? null : { alt: ["Alt tag must be set"] }),
+    { caption: "", useSrc: { value: true }, altText: "" }
   );

--- a/src/embeds/image/embed.tsx
+++ b/src/embeds/image/embed.tsx
@@ -2,17 +2,15 @@ import React from "react";
 import { createReactEmbedRenderer } from "../../mounters/react/mount";
 import { ImageEmbed } from "./ImageEmbed";
 
-export const imageProps = [
-  {
+export const imageProps = {
+  caption: {
     type: "richText",
-    name: "caption",
   },
-  {
+  altText: {
     type: "richText",
-    name: "altText",
   },
-  { type: "checkbox", name: "useSrc", defaultValue: false },
-] as const;
+  useSrc: { type: "checkbox", defaultValue: false },
+} as const;
 
 export const createImageEmbed = <Name extends string>(name: Name) =>
   createReactEmbedRenderer(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,17 @@ import { schema as basicSchema } from "prosemirror-schema-basic";
 import type { Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { build } from "./embed";
+import { buildEmbedPlugin } from "./embed";
 import { createImageEmbed } from "./embeds/image/embed";
 import { createParsers, docToHtml, htmlToDoc } from "./prosemirrorSetup";
 import { testDecorationPlugin } from "./testHelpers";
 
-const { plugin: embedPlugin, insertEmbed, hasErrors, nodeSpec } = build([
-  createImageEmbed("imageEmbed"),
-]);
+const {
+  plugin: embedPlugin,
+  insertEmbed,
+  hasErrors,
+  nodeSpec,
+} = buildEmbedPlugin([createImageEmbed("imageEmbed")]);
 
 const schema = new Schema({
   nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
@@ -63,7 +66,7 @@ const embedButton = document.createElement("button");
 embedButton.innerHTML = "Embed";
 embedButton.id = "embed";
 embedButton.addEventListener("click", () =>
-  insertEmbed("imageEmbed", { alt: "", caption: "", src: "" })(
+  insertEmbed("imageEmbed", { altText: "", caption: "" })(
     view.state,
     view.dispatch
   )

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -57,7 +57,7 @@ export const mount = <
   render: TRenderer<RenderOutput, Props>,
   consumer: TConsumer<RenderOutput, Props>,
   validate: Validator<Props>,
-  defaultState: NodeViewPropValues<Props>
+  defaultState: Partial<NodeViewPropValues<Props>>
 ): TEmbed<Props, Name> => ({
   name,
   props,

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -2,7 +2,7 @@ import { getNodeSpecFromProps } from "./nodeSpec";
 import type { TCommandCreator, TCommands } from "./types/Commands";
 import type { TConsumer } from "./types/Consumer";
 import type {
-  ElementProps,
+  EmbedProps,
   NodeViewPropMapFromProps,
   TEmbed,
 } from "./types/Embed";
@@ -29,7 +29,7 @@ const createUpdater = (): Updater => {
   };
 };
 
-export type TRenderer<RendererOutput, Props extends ElementProps> = (
+export type TRenderer<RendererOutput, Props extends EmbedProps<string>> = (
   consumer: TConsumer<RendererOutput, Props>,
   validate: TValidator,
   // The HTMLElement representing the node parent. The renderer can mount onto this node.
@@ -47,7 +47,7 @@ export type TRenderer<RendererOutput, Props extends ElementProps> = (
 
 export const mount = <
   RenderOutput,
-  Props extends ElementProps,
+  Props extends EmbedProps<string>,
   Name extends string
 >(
   name: Name,

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -15,7 +15,7 @@ const fieldErrors = <FSpec extends FieldSpec<string>>(
   Object.keys(fields).reduce(
     (acc, key) => ({
       ...acc,
-      [key]: errors ? errors[key] : [],
+      [key]: errors?.[key] ? errors[key] : [],
     }),
     {}
   );
@@ -91,14 +91,15 @@ export class EmbedProvider<FSpec extends FieldSpec<string>> extends Component<
   }
 
   render() {
+    const errors = fieldErrors(
+      this.state.fields,
+      this.props.validate(this.state.fields)
+    );
     return (
       <EmbedWrapper name="Image" {...this.state.commands}>
         {this.props.consumer(
           this.state.fields,
-          fieldErrors(
-            this.state.fields,
-            this.props.validate(this.state.fields)
-          ),
+          errors,
           this.updateFields,
           this.props.nestedEditors
         )}

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -1,15 +1,15 @@
 import type { ReactElement } from "react";
 import React, { Component } from "react";
 import type { Validator } from "../../mount";
-import type { NodeViewPropValues } from "../../nodeViews/helpers";
+import type { FieldNameToValueMap } from "../../nodeViews/helpers";
 import type { TCommands } from "../../types/Commands";
 import type { TConsumer } from "../../types/Consumer";
-import type { EmbedProps, NodeViewPropMap } from "../../types/Embed";
+import type { FieldNameToNodeViewSpec, FieldSpec } from "../../types/Embed";
 import type { TErrors } from "../../types/Errors";
 import { EmbedWrapper } from "./EmbedWrapper";
 
-const fieldErrors = <Props extends EmbedProps<string>>(
-  fields: NodeViewPropValues<Props>,
+const fieldErrors = <FSpec extends FieldSpec<string>>(
+  fields: FieldNameToValueMap<FSpec>,
   errors: TErrors | null
 ) =>
   Object.keys(fields).reduce(
@@ -20,28 +20,28 @@ const fieldErrors = <Props extends EmbedProps<string>>(
     {}
   );
 
-type IProps<Props extends EmbedProps<string>> = {
+type IProps<FSpec extends FieldSpec<string>> = {
   subscribe: (
-    fn: (fields: NodeViewPropValues<Props>, commands: TCommands) => void
+    fn: (fields: FieldNameToValueMap<FSpec>, commands: TCommands) => void
   ) => void;
   commands: TCommands;
-  fields: NodeViewPropValues<Props>;
-  onStateChange: (fields: NodeViewPropValues<Props>) => void;
-  validate: Validator<Props>;
-  consumer: TConsumer<ReactElement, Props>;
-  nestedEditors: NodeViewPropMap<Props>;
+  fields: FieldNameToValueMap<FSpec>;
+  onStateChange: (fields: FieldNameToValueMap<FSpec>) => void;
+  validate: Validator<FSpec>;
+  consumer: TConsumer<ReactElement, FSpec>;
+  nestedEditors: FieldNameToNodeViewSpec<FSpec>;
 };
 
-type IState<Props extends EmbedProps<string>> = {
+type IState<FSpec extends FieldSpec<string>> = {
   commands: TCommands;
-  fields: NodeViewPropValues<Props>;
+  fields: FieldNameToValueMap<FSpec>;
 };
 
-export class EmbedProvider<Props extends EmbedProps<string>> extends Component<
-  IProps<Props>,
-  IState<Props>
+export class EmbedProvider<FSpec extends FieldSpec<string>> extends Component<
+  IProps<FSpec>,
+  IState<FSpec>
 > {
-  constructor(props: IProps<Props>) {
+  constructor(props: IProps<FSpec>) {
     super(props);
 
     this.updateFields = this.updateFields.bind(this);
@@ -71,7 +71,7 @@ export class EmbedProvider<Props extends EmbedProps<string>> extends Component<
     this.props.onStateChange(this.state.fields);
   }
 
-  updateState(state: Partial<IState<Props>>, notifyListeners: boolean): void {
+  updateState(state: Partial<IState<FSpec>>, notifyListeners: boolean): void {
     this.setState(
       { ...this.state, ...state },
       () => notifyListeners && this.onStateChange()

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -1,14 +1,17 @@
 import type { ReactElement } from "react";
 import React, { Component } from "react";
+import type { Validator } from "../../mount";
+import type { NodeViewPropValues } from "../../nodeViews/helpers";
 import type { TCommands } from "../../types/Commands";
 import type { TConsumer } from "../../types/Consumer";
-import type { EmbedProps, NodeViewPropMapFromProps } from "../../types/Embed";
+import type { EmbedProps, NodeViewPropMap } from "../../types/Embed";
 import type { TErrors } from "../../types/Errors";
-import type { TFields } from "../../types/Fields";
-import type { TValidator } from "../../types/Validator";
 import { EmbedWrapper } from "./EmbedWrapper";
 
-const fieldErrors = (fields: TFields, errors: TErrors | null) =>
+const fieldErrors = <Props extends EmbedProps<string>>(
+  fields: NodeViewPropValues<Props>,
+  errors: TErrors | null
+) =>
   Object.keys(fields).reduce(
     (acc, key) => ({
       ...acc,
@@ -18,23 +21,25 @@ const fieldErrors = (fields: TFields, errors: TErrors | null) =>
   );
 
 type IProps<Props extends EmbedProps<string>> = {
-  subscribe: (fn: (fields: TFields, commands: TCommands) => void) => void;
+  subscribe: (
+    fn: (fields: NodeViewPropValues<Props>, commands: TCommands) => void
+  ) => void;
   commands: TCommands;
-  fields: TFields;
-  onStateChange: (fields: TFields) => void;
-  validate: TValidator;
+  fields: NodeViewPropValues<Props>;
+  onStateChange: (fields: NodeViewPropValues<Props>) => void;
+  validate: Validator<Props>;
   consumer: TConsumer<ReactElement, Props>;
-  nestedEditors: NodeViewPropMapFromProps<Props>;
+  nestedEditors: NodeViewPropMap<Props>;
 };
 
-type IState = {
+type IState<Props extends EmbedProps<string>> = {
   commands: TCommands;
-  fields: TFields;
+  fields: NodeViewPropValues<Props>;
 };
 
 export class EmbedProvider<Props extends EmbedProps<string>> extends Component<
   IProps<Props>,
-  IState
+  IState<Props>
 > {
   constructor(props: IProps<Props>) {
     super(props);
@@ -66,7 +71,7 @@ export class EmbedProvider<Props extends EmbedProps<string>> extends Component<
     this.props.onStateChange(this.state.fields);
   }
 
-  updateState(state: Partial<IState>, notifyListeners: boolean): void {
+  updateState(state: Partial<IState<Props>>, notifyListeners: boolean): void {
     this.setState(
       { ...this.state, ...state },
       () => notifyListeners && this.onStateChange()

--- a/src/mounters/react/EmbedProvider.tsx
+++ b/src/mounters/react/EmbedProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import React, { Component } from "react";
 import type { TCommands } from "../../types/Commands";
 import type { TConsumer } from "../../types/Consumer";
-import type { ElementProps, NodeViewPropMapFromProps } from "../../types/Embed";
+import type { EmbedProps, NodeViewPropMapFromProps } from "../../types/Embed";
 import type { TErrors } from "../../types/Errors";
 import type { TFields } from "../../types/Fields";
 import type { TValidator } from "../../types/Validator";
@@ -17,7 +17,7 @@ const fieldErrors = (fields: TFields, errors: TErrors | null) =>
     {}
   );
 
-type IProps<Props extends ElementProps> = {
+type IProps<Props extends EmbedProps<string>> = {
   subscribe: (fn: (fields: TFields, commands: TCommands) => void) => void;
   commands: TCommands;
   fields: TFields;
@@ -32,7 +32,7 @@ type IState = {
   fields: TFields;
 };
 
-export class EmbedProvider<Props extends ElementProps> extends Component<
+export class EmbedProvider<Props extends EmbedProps<string>> extends Component<
   IProps<Props>,
   IState
 > {

--- a/src/mounters/react/PropView.tsx
+++ b/src/mounters/react/PropView.tsx
@@ -16,11 +16,11 @@ export const PropView: React.FunctionComponent<Props> = ({ nodeViewProp }) => {
     editorRef.current.appendChild(nodeViewProp.nodeView.nodeViewElement);
   }, []);
   return (
-    <div data-cy={getPropViewTestId(nodeViewProp.prop.name)}>
+    <div data-cy={getPropViewTestId(nodeViewProp.name)}>
       <label>
-        <strong>{nodeViewProp.prop.name}</strong>
+        <strong>{nodeViewProp.name}</strong>
       </label>
-      <div className="NestedEditorView" ref={editorRef}></div>
+      <div ref={editorRef}></div>
     </div>
   );
 };

--- a/src/mounters/react/PropView.tsx
+++ b/src/mounters/react/PropView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef } from "react";
-import type { NodeViewProp } from "../../types/Embed";
+import type { FieldNodeViewSpec } from "../../types/Embed";
 
 type Props = {
-  nodeViewProp: NodeViewProp;
+  nodeViewProp: FieldNodeViewSpec;
 };
 
 export const getPropViewTestId = (name: string) => `PropField-${name}`;

--- a/src/mounters/react/mount.tsx
+++ b/src/mounters/react/mount.tsx
@@ -4,13 +4,13 @@ import { render } from "react-dom";
 import { mount } from "../../mount";
 import type { TRenderer } from "../../mount";
 import type { TConsumer } from "../../types/Consumer";
-import type { ElementProps } from "../../types/Embed";
+import type { EmbedProps } from "../../types/Embed";
 import type { TFields } from "../../types/Fields";
 import type { TValidator } from "../../types/Validator";
 import { EmbedProvider } from "./EmbedProvider";
 
 export const createReactEmbedRenderer = <
-  Props extends ElementProps,
+  Props extends EmbedProps<string>,
   Name extends string
 >(
   name: Name,

--- a/src/mounters/react/mount.tsx
+++ b/src/mounters/react/mount.tsx
@@ -3,22 +3,22 @@ import React from "react";
 import { render } from "react-dom";
 import { mount } from "../../mount";
 import type { TRenderer, Validator } from "../../mount";
-import type { NodeViewPropValues } from "../../nodeViews/helpers";
+import type { FieldNameToValueMap } from "../../nodeViews/helpers";
 import type { TConsumer } from "../../types/Consumer";
-import type { EmbedProps } from "../../types/Embed";
+import type { FieldSpec } from "../../types/Embed";
 import { EmbedProvider } from "./EmbedProvider";
 
 export const createReactEmbedRenderer = <
-  Props extends EmbedProps<string>,
+  FSpec extends FieldSpec<string>,
   Name extends string
 >(
   name: Name,
-  props: Props,
-  consumer: TConsumer<ReactElement, Props>,
-  validate: Validator<Props>,
-  defaultState: NodeViewPropValues<Props>
+  fieldSpec: FSpec,
+  consumer: TConsumer<ReactElement, FSpec>,
+  validate: Validator<FSpec>,
+  defaultState: FieldNameToValueMap<FSpec>
 ) => {
-  const renderer: TRenderer<ReactElement, Props> = (
+  const renderer: TRenderer<ReactElement, FSpec> = (
     consumer,
     validate,
     dom,
@@ -29,7 +29,7 @@ export const createReactEmbedRenderer = <
     subscribe
   ) =>
     render(
-      <EmbedProvider<Props>
+      <EmbedProvider<FSpec>
         subscribe={subscribe}
         onStateChange={updateState}
         fields={fields}
@@ -41,5 +41,5 @@ export const createReactEmbedRenderer = <
       dom
     );
 
-  return mount(name, props, renderer, consumer, validate, defaultState);
+  return mount(name, fieldSpec, renderer, consumer, validate, defaultState);
 };

--- a/src/mounters/react/mount.tsx
+++ b/src/mounters/react/mount.tsx
@@ -2,11 +2,10 @@ import type { ReactElement } from "react";
 import React from "react";
 import { render } from "react-dom";
 import { mount } from "../../mount";
-import type { TRenderer } from "../../mount";
+import type { TRenderer, Validator } from "../../mount";
+import type { NodeViewPropValues } from "../../nodeViews/helpers";
 import type { TConsumer } from "../../types/Consumer";
 import type { EmbedProps } from "../../types/Embed";
-import type { TFields } from "../../types/Fields";
-import type { TValidator } from "../../types/Validator";
 import { EmbedProvider } from "./EmbedProvider";
 
 export const createReactEmbedRenderer = <
@@ -16,8 +15,8 @@ export const createReactEmbedRenderer = <
   name: Name,
   props: Props,
   consumer: TConsumer<ReactElement, Props>,
-  validate: TValidator,
-  defaultState: TFields
+  validate: Validator<Props>,
+  defaultState: NodeViewPropValues<Props>
 ) => {
   const renderer: TRenderer<ReactElement, Props> = (
     consumer,

--- a/src/nodeSpec.ts
+++ b/src/nodeSpec.ts
@@ -1,27 +1,27 @@
 import OrderedMap from "orderedmap";
 import type { Node, NodeSpec } from "prosemirror-model";
-import type { EmbedProps, PropSpec } from "./types/Embed";
+import type { Field, FieldSpec } from "./types/Embed";
 
-export const getNodeSpecFromProps = <Props extends EmbedProps<string>>(
+export const getNodeSpecFromFieldSpec = <FSpec extends FieldSpec<string>>(
   embedName: string,
-  props: Props
+  fieldSpec: FSpec
 ): OrderedMap<NodeSpec> => {
-  const propSpecs = Object.entries(props).reduce(
+  const propSpecs = Object.entries(fieldSpec).reduce(
     (acc, [propName, propSpec]) =>
       acc.append(getNodeSpecForProp(embedName, propName, propSpec)),
     OrderedMap.from<NodeSpec>({})
   );
 
-  return propSpecs.append(getNodeSpecForEmbed(embedName, props));
+  return propSpecs.append(getNodeSpecForEmbed(embedName, fieldSpec));
 };
 
 const getNodeSpecForEmbed = (
   embedName: string,
-  props: EmbedProps<string>
+  fieldSpec: FieldSpec<string>
 ): NodeSpec => ({
   [embedName]: {
     group: "block",
-    content: Object.keys(props).join(" "),
+    content: Object.keys(fieldSpec).join(" "),
     attrs: {
       type: embedName,
       hasErrors: {
@@ -61,7 +61,7 @@ const getNodeSpecForEmbed = (
 const getNodeSpecForProp = (
   embedName: string,
   propName: string,
-  prop: PropSpec
+  prop: Field
 ): NodeSpec => {
   switch (prop.type) {
     case "richText":

--- a/src/nodeViews/CheckboxNodeView.ts
+++ b/src/nodeViews/CheckboxNodeView.ts
@@ -1,9 +1,15 @@
+import type { Node } from "prosemirror-model";
 import { FieldNodeView } from "./FieldNodeView";
 
-type CheckboxFields = { value: boolean };
+export type CheckboxFields = { value: boolean };
 
 export class CheckboxNodeView extends FieldNodeView<CheckboxFields> {
+  public static propName = "checkbox" as const;
   private checkboxElement: HTMLInputElement | undefined = undefined;
+
+  public getNodeValue(node: Node): CheckboxFields {
+    return node.attrs.fields as CheckboxFields;
+  }
 
   protected createInnerView({ value }: CheckboxFields): void {
     this.checkboxElement = document.createElement("input");

--- a/src/nodeViews/EmbedNodeView.ts
+++ b/src/nodeViews/EmbedNodeView.ts
@@ -4,13 +4,15 @@ import type { Decoration, DecorationSet } from "prosemirror-view";
 /**
  * Represents a prosemirror-embed view of a Prosemirror Node.
  */
-export interface EmbedNodeView {
-  nodeViewElement: HTMLElement;
+export abstract class EmbedNodeView<NodeValue> {
+  public static propName: string;
+  // The HTML element this nodeView renders content into.
+  public abstract nodeViewElement: HTMLElement;
 
   /**
    * Called when the nodeView is updated.
    */
-  update(
+  public abstract update(
     node: Node,
     elementOffset: number,
     decorations: DecorationSet | Decoration[]
@@ -19,5 +21,10 @@ export interface EmbedNodeView {
   /**
    * Called when the nodeView is destroyed.
    */
-  destroy(): void;
+  public abstract destroy(): void;
+
+  /**
+   * Get the value from a given node that's represented by this NodeView.
+   */
+  public abstract getNodeValue(node: Node): NodeValue;
 }

--- a/src/nodeViews/FieldNodeView.ts
+++ b/src/nodeViews/FieldNodeView.ts
@@ -33,10 +33,12 @@ export abstract class FieldNodeView<Fields extends unknown>
 
   protected abstract updateInnerView(fields: Fields): void;
 
-  public update(node: Node) {
+  public update(node: Node, elementOffset: number) {
     if (!node.sameMarkup(this.node)) {
       return false;
     }
+
+    this.offset = elementOffset;
 
     this.updateInnerView(node.attrs as Fields);
 
@@ -56,6 +58,7 @@ export abstract class FieldNodeView<Fields extends unknown>
     //  - getPos() returns the position directly before the parent node (+1)
     const contentOffset = 1;
     const nodePos = this.getPos() + this.offset + contentOffset;
+    console.log(nodePos);
     outerTr.setNodeMarkup(nodePos, undefined, {
       fields,
     });

--- a/src/nodeViews/FieldNodeView.ts
+++ b/src/nodeViews/FieldNodeView.ts
@@ -7,7 +7,8 @@ import type { EmbedNodeView } from "./EmbedNodeView";
  * node that contains fields that are updated atomically.
  */
 export abstract class FieldNodeView<Fields extends unknown>
-  implements EmbedNodeView {
+  implements EmbedNodeView<Fields> {
+  public static propName: string;
   // The parent DOM element for this view. Public
   // so it can be mounted by consuming elements.
   public nodeViewElement = document.createElement("div");
@@ -25,6 +26,8 @@ export abstract class FieldNodeView<Fields extends unknown>
   ) {
     this.createInnerView(node.attrs.fields || defaultFields);
   }
+
+  public abstract getNodeValue(node: Node): Fields;
 
   protected abstract createInnerView(fields: Fields): void;
 

--- a/src/nodeViews/FieldNodeView.ts
+++ b/src/nodeViews/FieldNodeView.ts
@@ -58,7 +58,7 @@ export abstract class FieldNodeView<Fields extends unknown>
     //  - getPos() returns the position directly before the parent node (+1)
     const contentOffset = 1;
     const nodePos = this.getPos() + this.offset + contentOffset;
-    console.log(nodePos);
+
     outerTr.setNodeMarkup(nodePos, undefined, {
       fields,
     });

--- a/src/nodeViews/helpers.ts
+++ b/src/nodeViews/helpers.ts
@@ -1,18 +1,18 @@
-import type { EmbedProps } from "../types/Embed";
+import type { FieldSpec } from "../types/Embed";
 import type { CheckboxFields, CheckboxNodeView } from "./CheckboxNodeView";
 import type { RTENodeView } from "./RTENodeView";
 
 /**
  * A map from all NodeView types to the values they create at runtime.
  */
-export type NodeViewValueMap = {
+export type FieldTypeToValueMap = {
   [CheckboxNodeView.propName]: CheckboxFields;
   [RTENodeView.propName]: string;
 };
 
 /**
- * Get the values that would be provided by the given PropSpecs at runtime,
- * keyed by their names. For example, for the props:
+ * Get the values that would be provided by the given FieldSpec at runtime,
+ * keyed by their names. For example, for the FieldSpec:
  *
  * `{ altText: { type: "richText" }, isVisible: { type: "checkbox" }}`
  *
@@ -20,6 +20,6 @@ export type NodeViewValueMap = {
  *
  * `{ altText: string }, { isVisible: { value: boolean }}`
  */
-export type NodeViewPropValues<Props extends EmbedProps<string>> = {
-  [Name in keyof Props]: NodeViewValueMap[Props[Name]["type"]];
+export type FieldNameToValueMap<FSpec extends FieldSpec<string>> = {
+  [Name in keyof FSpec]: FieldTypeToValueMap[FSpec[Name]["type"]];
 };

--- a/src/nodeViews/helpers.ts
+++ b/src/nodeViews/helpers.ts
@@ -1,0 +1,25 @@
+import type { EmbedProps } from "../types/Embed";
+import type { CheckboxFields, CheckboxNodeView } from "./CheckboxNodeView";
+import type { RTENodeView } from "./RTENodeView";
+
+/**
+ * A map from all NodeView types to the values they create at runtime.
+ */
+export type NodeViewValueMap = {
+  [CheckboxNodeView.propName]: CheckboxFields;
+  [RTENodeView.propName]: string;
+};
+
+/**
+ * Get the values that would be provided by the given PropSpecs at runtime,
+ * keyed by their names. For example, for the props:
+ *
+ * `{ altText: { type: "richText" }, isVisible: { type: "checkbox" }}`
+ *
+ * The resulting type would be:
+ *
+ * `{ altText: string }, { isVisible: { value: boolean }}`
+ */
+export type NodeViewPropValues<Props extends EmbedProps<string>> = {
+  [Name in keyof Props]: NodeViewValueMap[Props[Name]["type"]];
+};

--- a/src/pluginHelpers.ts
+++ b/src/pluginHelpers.ts
@@ -4,7 +4,7 @@ import { schema } from "prosemirror-schema-basic";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { CheckboxNodeView } from "./nodeViews/CheckboxNodeView";
 import { RTENodeView } from "./nodeViews/RTENodeView";
-import type { ElementProp } from "./types/Embed";
+import type { PropSpec } from "./types/Embed";
 
 const temporaryHardcodedSchema = new Schema({
   nodes: schema.spec.nodes,
@@ -20,7 +20,7 @@ type Options = {
 };
 
 export const getEmbedNodeViewFromType = (
-  prop: ElementProp,
+  prop: PropSpec,
   { node, view, getPos, offset, innerDecos }: Options
 ) => {
   switch (prop.type) {

--- a/src/pluginHelpers.ts
+++ b/src/pluginHelpers.ts
@@ -4,7 +4,7 @@ import { schema } from "prosemirror-schema-basic";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { CheckboxNodeView } from "./nodeViews/CheckboxNodeView";
 import { RTENodeView } from "./nodeViews/RTENodeView";
-import type { PropSpec } from "./types/Embed";
+import type { Field } from "./types/Embed";
 
 const temporaryHardcodedSchema = new Schema({
   nodes: schema.spec.nodes,
@@ -20,7 +20,7 @@ type Options = {
 };
 
 export const getEmbedNodeViewFromType = (
-  prop: PropSpec,
+  prop: Field,
   { node, view, getPos, offset, innerDecos }: Options
 ) => {
   switch (prop.type) {

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -1,8 +1,8 @@
-import type { ElementProps, NodeViewPropMapFromProps } from "./Embed";
+import type { EmbedProps, NodeViewPropMapFromProps } from "./Embed";
 import type { TErrors } from "./Errors";
 import type { TFields } from "./Fields";
 
-export type TConsumer<ConsumerResult, Props extends ElementProps> = (
+export type TConsumer<ConsumerResult, Props extends EmbedProps<string>> = (
   fields: TFields,
   errors: TErrors,
   updateFields: (fields: TFields) => void,

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -1,10 +1,10 @@
-import type { NodeViewPropValues } from "../nodeViews/helpers";
-import type { EmbedProps, NodeViewPropMap } from "./Embed";
+import type { FieldNameToValueMap } from "../nodeViews/helpers";
+import type { FieldNameToNodeViewSpec, FieldSpec } from "./Embed";
 import type { TErrors } from "./Errors";
 
-export type TConsumer<ConsumerResult, Props extends EmbedProps<string>> = (
-  fields: NodeViewPropValues<Props>,
+export type TConsumer<ConsumerResult, FSpec extends FieldSpec<string>> = (
+  fields: FieldNameToValueMap<FSpec>,
   errors: TErrors,
-  updateFields: (fields: NodeViewPropValues<Props>) => void,
-  nestedEditors: NodeViewPropMap<Props>
+  updateFields: (fields: FieldNameToValueMap<FSpec>) => void,
+  nestedEditors: FieldNameToNodeViewSpec<FSpec>
 ) => ConsumerResult;

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -1,11 +1,10 @@
 import type { NodeViewPropValues } from "../nodeViews/helpers";
 import type { EmbedProps, NodeViewPropMap } from "./Embed";
 import type { TErrors } from "./Errors";
-import type { TFields } from "./Fields";
 
 export type TConsumer<ConsumerResult, Props extends EmbedProps<string>> = (
   fields: NodeViewPropValues<Props>,
   errors: TErrors,
-  updateFields: (fields: TFields) => void,
+  updateFields: (fields: NodeViewPropValues<Props>) => void,
   nestedEditors: NodeViewPropMap<Props>
 ) => ConsumerResult;

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -1,10 +1,11 @@
-import type { EmbedProps, NodeViewPropMapFromProps } from "./Embed";
+import type { NodeViewPropValues } from "../nodeViews/helpers";
+import type { EmbedProps, NodeViewPropMap } from "./Embed";
 import type { TErrors } from "./Errors";
 import type { TFields } from "./Fields";
 
 export type TConsumer<ConsumerResult, Props extends EmbedProps<string>> = (
-  fields: TFields,
+  fields: NodeViewPropValues<Props>,
   errors: TErrors,
   updateFields: (fields: TFields) => void,
-  nestedEditors: NodeViewPropMapFromProps<Props>
+  nestedEditors: NodeViewPropMap<Props>
 ) => ConsumerResult;

--- a/src/types/Embed.ts
+++ b/src/types/Embed.ts
@@ -1,63 +1,63 @@
 import type { NodeSpec, Schema } from "prosemirror-model";
 import type { CheckboxNodeView } from "../nodeViews/CheckboxNodeView";
-import type { NodeViewPropValues } from "../nodeViews/helpers";
+import type { FieldNameToValueMap } from "../nodeViews/helpers";
 import type { RTENodeView } from "../nodeViews/RTENodeView";
 import type { TCommandCreator } from "./Commands";
 
 /**
- * The specification for an embed property, to be modelled as a Node in Prosemirror.
+ * The specification for an embed field, to be modelled as a Node in Prosemirror.
  */
-interface BasePropSpec {
-  // The data type of the property.
+interface BaseFieldSpec {
+  // The data type of the field.
   type: string;
 }
 
-interface CheckboxProp extends BasePropSpec {
+interface CheckboxField extends BaseFieldSpec {
   type: typeof CheckboxNodeView.propName;
   defaultValue: boolean;
 }
 
-interface RTEProp
-  extends BasePropSpec,
+interface RTEField
+  extends BaseFieldSpec,
     Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
   type: typeof RTENodeView.propName;
 }
 
-export type PropSpec = RTEProp | CheckboxProp;
+export type Field = RTEField | CheckboxField;
 
-export type EmbedProps<Names extends string> = Record<Names, PropSpec>;
+export type FieldSpec<Names extends string> = Record<Names, Field>;
 
-export type SchemaFromProps<Props extends EmbedProps<string>> = Schema<
-  Extract<keyof Props, string>
+export type SchemaFromEmbedFieldSpec<FSpec extends FieldSpec<string>> = Schema<
+  Extract<keyof FSpec, string>
 >;
 
-export type EmbedNodeViews = RTENodeView | CheckboxNodeView;
+export type FieldNodeViews = RTENodeView | CheckboxNodeView;
 
-export type NodeViewProp = {
-  nodeView: EmbedNodeViews;
-  prop: PropSpec;
+export type FieldNodeViewSpec = {
+  nodeView: FieldNodeViews;
+  fieldSpec: Field;
   name: string;
 };
 
-export type NodeViewPropMap<Props extends EmbedProps<string>> = {
-  [name in Extract<keyof Props, string>]: NodeViewProp;
+export type FieldNameToNodeViewSpec<FSpec extends FieldSpec<string>> = {
+  [name in Extract<keyof FSpec, string>]: FieldNodeViewSpec;
 };
 
-export type TEmbed<Props extends EmbedProps<string>, Name extends string> = {
+export type TEmbed<FSpec extends FieldSpec<string>, Name extends string> = {
   name: Name;
-  props: Props;
+  fieldSpec: FSpec;
   nodeSpec: NodeSpec;
   createUpdator: (
     dom: HTMLElement,
-    nestedEditors: NodeViewPropMap<Props>,
+    nestedEditors: FieldNameToNodeViewSpec<FSpec>,
     updateState: (
-      fields: NodeViewPropValues<Props>,
+      fields: FieldNameToValueMap<FSpec>,
       hasErrors: boolean
     ) => void,
-    initFields: NodeViewPropValues<Props>,
+    initFields: FieldNameToValueMap<FSpec>,
     commands: ReturnType<TCommandCreator>
   ) => (
-    fields: NodeViewPropValues<Props>,
+    fields: FieldNameToValueMap<FSpec>,
     commands: ReturnType<TCommandCreator>
   ) => void;
 };

--- a/src/types/Embed.ts
+++ b/src/types/Embed.ts
@@ -4,46 +4,43 @@ import type { TCommandCreator } from "./Commands";
 import type { TFields } from "./Fields";
 
 /**
- * A property of an embed, to be modelled as a Node in Prosemirror.
+ * The specification for an embed property, to be modelled as a Node in Prosemirror.
  */
-interface Prop {
+interface BasePropSpec {
   // The data type of the property.
   type: string;
-  // The name the property should have in the schema. Should be unique within the schema.
-  name: string;
 }
 
-interface CheckboxProp extends Prop {
+interface CheckboxProp extends BasePropSpec {
   type: "checkbox";
-  name: string;
   defaultValue: boolean;
 }
 
 interface RTEProp
-  extends Prop,
+  extends BasePropSpec,
     Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
   type: "richText";
-  name: string;
 }
 
-export type ElementProp = RTEProp | CheckboxProp;
+export type PropSpec = RTEProp | CheckboxProp;
 
-export type ElementProps = Readonly<ElementProp[]>;
+export type EmbedProps<Names extends string> = Record<Names, PropSpec>;
 
-export type SchemaFromProps<Props extends ElementProps> = Schema<
-  Props[number]["name"]
+export type SchemaFromProps<Props extends EmbedProps<string>> = Schema<
+  Extract<keyof Props, string>
 >;
 
 export type NodeViewProp = {
   nodeView: EmbedNodeView;
-  prop: ElementProp;
+  prop: PropSpec;
+  name: string;
 };
 
-export type NodeViewPropMapFromProps<Props extends ElementProps> = {
-  [name in Props[number]["name"]]: NodeViewProp;
+export type NodeViewPropMapFromProps<Props extends EmbedProps<string>> = {
+  [name in Extract<keyof Props, string>]: NodeViewProp;
 };
 
-export type TEmbed<Props extends ElementProps, Name extends string> = {
+export type TEmbed<Props extends EmbedProps<string>, Name extends string> = {
   name: Name;
   props: Props;
   nodeSpec: NodeSpec;

--- a/src/types/Embed.ts
+++ b/src/types/Embed.ts
@@ -1,7 +1,8 @@
 import type { NodeSpec, Schema } from "prosemirror-model";
-import type { EmbedNodeView } from "../nodeViews/EmbedNodeView";
+import type { CheckboxNodeView } from "../nodeViews/CheckboxNodeView";
+import type { NodeViewPropValues } from "../nodeViews/helpers";
+import type { RTENodeView } from "../nodeViews/RTENodeView";
 import type { TCommandCreator } from "./Commands";
-import type { TFields } from "./Fields";
 
 /**
  * The specification for an embed property, to be modelled as a Node in Prosemirror.
@@ -12,14 +13,14 @@ interface BasePropSpec {
 }
 
 interface CheckboxProp extends BasePropSpec {
-  type: "checkbox";
+  type: typeof CheckboxNodeView.propName;
   defaultValue: boolean;
 }
 
 interface RTEProp
   extends BasePropSpec,
     Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
-  type: "richText";
+  type: typeof RTENodeView.propName;
 }
 
 export type PropSpec = RTEProp | CheckboxProp;
@@ -30,13 +31,15 @@ export type SchemaFromProps<Props extends EmbedProps<string>> = Schema<
   Extract<keyof Props, string>
 >;
 
+export type EmbedNodeViews = RTENodeView | CheckboxNodeView;
+
 export type NodeViewProp = {
-  nodeView: EmbedNodeView;
+  nodeView: EmbedNodeViews;
   prop: PropSpec;
   name: string;
 };
 
-export type NodeViewPropMapFromProps<Props extends EmbedProps<string>> = {
+export type NodeViewPropMap<Props extends EmbedProps<string>> = {
   [name in Extract<keyof Props, string>]: NodeViewProp;
 };
 
@@ -46,9 +49,15 @@ export type TEmbed<Props extends EmbedProps<string>, Name extends string> = {
   nodeSpec: NodeSpec;
   createUpdator: (
     dom: HTMLElement,
-    nestedEditors: NodeViewPropMapFromProps<Props>,
-    updateState: (fields: TFields, hasErrors: boolean) => void,
-    initFields: TFields,
+    nestedEditors: NodeViewPropMap<Props>,
+    updateState: (
+      fields: NodeViewPropValues<Props>,
+      hasErrors: boolean
+    ) => void,
+    initFields: NodeViewPropValues<Props>,
     commands: ReturnType<TCommandCreator>
-  ) => (fields: TFields, commands: ReturnType<TCommandCreator>) => void;
+  ) => (
+    fields: NodeViewPropValues<Props>,
+    commands: ReturnType<TCommandCreator>
+  ) => void;
 };

--- a/src/types/Fields.ts
+++ b/src/types/Fields.ts
@@ -1,1 +1,0 @@
-export type TFields = Record<string, string>;

--- a/src/types/Validator.ts
+++ b/src/types/Validator.ts
@@ -1,3 +1,0 @@
-import type { TFields } from "./Fields";
-
-export type TValidator = (fields: TFields) => null | Record<string, string[]>;


### PR DESCRIPTION
## What does this change?

This PR gets rid of the last vestiges of the previous sort of state management (a single, empty parent node, with lots of fields), in favour of the current sort of state management (one to many child nodes, which have content or fields).

We now display the current values of the fields, and their validation output, to show that everything's working as intended:

<img width="808" alt="Screenshot 2021-05-17 at 17 38 05" src="https://user-images.githubusercontent.com/7767575/118525033-a936f400-b736-11eb-9754-cbb8cc0516a2.png">

In doing the above, I've tried to 
- keep things as typesafe as possible. As a result, the validation and field values passed to the consumer code are now typesafe, with tests
- tried to name things sensibly, and comment the more complicated type wrangling that's needed for the above.

As a result, this diff is larger than I intended, mainly because there's lots of renaming – v. happy to pair on reviewing.

There's one bug, which is longstanding but only visible now – initial values aren't reflected in the field values until the editor state changes. That'll have to wait for another PR.

## How to test

- The automated tests should pass. The new ones should make us feel confident we've got the types right
- The names for types should make at least _some_ sense. Lmk if things need renaming, or bear some explanation w/ comments.
